### PR TITLE
Try to reduce copypasta and rooting around in Composer internals

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositoryFactory;
+use Composer\Repository\RepositoryManager;
 use Tuf\ComposerIntegration\Repository\TufValidatedComposerRepository;
 
 class Plugin implements PluginInterface
@@ -16,31 +17,37 @@ class Plugin implements PluginInterface
      */
     public function activate(Composer $composer, IOInterface $io)
     {
-        $loop = $composer->getLoop();
-        $httpDownloader = $loop->getHttpDownloader();
-        $dispatcher = $composer->getEventDispatcher();
-        $config = $composer->getConfig();
-
         // By the time this plugin is activated, several repositories may have
         // already been instantiated, and we need to convert them to
         // TUF-validated repositories. Unfortunately, the repository manager
         // only allows us to add new repositories, not replace existing ones.
         // So we have to rebuild the repository manager from the ground up to
         // add TUF validation to the existing repositories.
-        $oldManager = $composer->getRepositoryManager();
-        $newManager = RepositoryFactory::manager($io, $config, $loop->getHttpDownloader(), $dispatcher, $loop->getProcessExecutor());
-        $newManager->setLocalRepository($oldManager->getLocalRepository());
-        // Ensure that any repositories added later will be validated by TUF if
-        // configured accordingly.
+        $newManager = $this->createNewRepositoryManager($composer, $io);
+        $this->addTufValidationToRepositories($composer, $newManager, $io);
+        $composer->setRepositoryManager($newManager);
+    }
+
+    private function createNewRepositoryManager(Composer $composer, IOInterface $io): RepositoryManager
+    {
+        $loop = $composer->getLoop();
+        $newManager = RepositoryFactory::manager($io, $composer->getConfig(), $loop->getHttpDownloader(), $composer->getEventDispatcher(), $loop->getProcessExecutor());
+        $newManager->setLocalRepository($composer->getRepositoryManager()->getLocalRepository());
+        // Ensure that any Composer repositories added to this manager will be
+        // validated by TUF if configured accordingly.
         $newManager->setRepositoryClass('composer', TufValidatedComposerRepository::class);
 
-        foreach ($oldManager->getRepositories() as $repository) {
+        return $newManager;
+    }
+
+    private function addTufValidationToRepositories(Composer $composer, RepositoryManager $manager, IOInterface $io): void
+    {
+        foreach ($composer->getRepositoryManager()->getRepositories() as $repository) {
             if ($repository instanceof ComposerRepository) {
-                $repository = new TufValidatedComposerRepository($repository->getRepoConfig(), $io, $config, $httpDownloader, $dispatcher);
+                $repository = new TufValidatedComposerRepository($repository->getRepoConfig(), $io, $composer->getConfig(), $composer->getLoop()->getHttpDownloader(), $composer->getEventDispatcher());
             }
-            $newManager->addRepository($repository);
+            $manager->addRepository($repository);
         }
-        $composer->setRepositoryManager($newManager);
     }
 
     /**

--- a/src/Repository/TufValidatedComposerRepository.php
+++ b/src/Repository/TufValidatedComposerRepository.php
@@ -62,7 +62,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             try {
                 $this->tufRepo->refresh();
             } catch (TufException $e) {
-                throw new RepositorySecurityException('TUF secure error: ' . $e->getMessage(), $e->getCode(), $e);
+                throw new RepositorySecurityException("TUF security error: {$e->getMessage()}", $e->getCode(), $e);
             }
         }
         return parent::loadRootServerFile();
@@ -82,7 +82,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             }
 
             // @todo: Investigate whether all $sha256 hashes, when provided, are trusted. Skip TUF if so.
-            if ($sha256 != null && $sha256 != $tufTargetInfo['hashes']['sha256']) {
+            if ($sha256 !== null && $sha256 !== $tufTargetInfo['hashes']['sha256']) {
                 throw new RepositorySecurityException('TUF secure error: disagreement between TUF and Composer repositories on expected hash of ' . $tufTarget);
             }
             $sha256 = $tufTargetInfo['hashes']['sha256'];

--- a/src/Repository/TufValidatedComposerRepository.php
+++ b/src/Repository/TufValidatedComposerRepository.php
@@ -31,6 +31,8 @@ class TufValidatedComposerRepository extends ComposerRepository
             $tufConfig = $repoConfig['tuf'];
 
             // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
+            // Convert the repo URL into a string that can be used as a
+            // directory name.
             $repoPath = preg_replace('{[^a-z0-9.]}i', '-', $repoConfig['url']);
             // Harvest the vendor dir from Composer. We'll store TUF state under vendor/composer/tuf.
             $vendorDir = rtrim($config->get('vendor-dir'), '/');

--- a/src/Repository/TufValidatedComposerRepository.php
+++ b/src/Repository/TufValidatedComposerRepository.php
@@ -33,7 +33,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
             // Convert the repo URL into a string that can be used as a
             // directory name.
-            $repoPath = preg_replace('{[^a-z0-9.]}i', '-', $repoConfig['url']);
+            $repoPath = preg_replace('/[^[:alnum:]\.]/', '-', $repoConfig['url']);
             // Harvest the vendor dir from Composer. We'll store TUF state under vendor/composer/tuf.
             $vendorDir = rtrim($config->get('vendor-dir'), '/');
             $repoPath = "$vendorDir/composer/tuf/repo/$repoPath";

--- a/src/Repository/TufValidatedComposerRepository.php
+++ b/src/Repository/TufValidatedComposerRepository.php
@@ -1,16 +1,10 @@
 <?php
 
-
 namespace Tuf\ComposerIntegration\Repository;
 
-
 use Composer\Config;
-use Composer\Downloader\TransportException;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
-use Composer\Json\JsonFile;
-use Composer\Plugin\PluginEvents;
-use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositorySecurityException;
 use Composer\Util\Filesystem;
@@ -22,93 +16,22 @@ use Tuf\Exception\TufException;
 class TufValidatedComposerRepository extends ComposerRepository
 {
     /**
-     * @var bool
-     *   Indicates whether this Composer repository is validated by a parallel
-     *   TUF repository.
-     */
-    protected $isValidated;
-
-    /**
-     * @var array
-     *   Cache to short-circuit TUF operations when accessing the Composer root metadata.
-     *
-     *   Serves same purpose as parent::$rootData, but its visibility is private.
-     */
-    protected $tufValidatedRootData;
-
-    /**
-     * @var array
-     *   HTTP request options.
-     */
-    protected $options;
-
-    /**
-     * @var bool
-     *   Indicates whether the repository is expected to have a functioning http fallback.
-     *
-     *   Unlike ComposerRepository, this defaults to true if not set by the root composer.json.
-     *   HTTPS is not the primary means of security in TUF-validated repositories.
-     */
-    protected $allowSslDowngrade;
-
-    /**
-     * @var string
-     *   The URL to the composer repository root.
-     *
-     *   Serves same purpose as parent::$url, but its visibility is private.
-     */
-    protected $composerRepoUrl;
-
-    /**
      * @var Updater
      */
     protected $tufRepo;
 
     /**
-     * @var EventDispatcher
+     * {@inheritDoc}
      */
-    protected $eventDispatcher;
-
-    /**
-     * @var HttpDownloader
-     */
-    protected $httpDownloader;
-
-    /**
-     * @var bool
-     */
-    protected $degradedMode = false;
-
-    /**
-     * @var IOInterface
-     */
-    protected $io;
-
     public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
     {
         parent::__construct($repoConfig, $io, $config, $httpDownloader, $eventDispatcher);
 
-        $this->isValidated = false;
-        $this->composerRepoUrl = $repoConfig['url'];
         if (!empty($repoConfig['tuf'])) {
-            $this->isValidated = true;
-            $this->eventDispatcher = $eventDispatcher;
-            $this->httpDownloader = $httpDownloader;
-            $this->io = $io;
-            if (!isset($repoConfig['options'])) {
-                $repoConfig['options'] = array();
-            }
-            $this->options = $repoConfig['options'];
-            $this->allowSslDowngrade = true;
-            if (array_key_exists('allow_ssl_downgrade', $repoConfig)) {
-                $this->allowSslDowngrade = $repoConfig['allow_ssl_downgrade'];
-            }
-
             $tufConfig = $repoConfig['tuf'];
 
             // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
-            $allowList = 'a-z0-9.';
-            $repoPath = preg_replace('{[^'.$allowList.']}i', '-', $this->composerRepoUrl);
+            $repoPath = preg_replace('{[^a-z0-9.]}i', '-', $repoConfig['url']);
             // Harvest the vendor dir from Composer. We'll store TUF state under vendor/composer/tuf.
             $vendorDir = rtrim($config->get('vendor-dir'), '/');
             $repoPath = "$vendorDir/composer/tuf/repo/$repoPath";
@@ -117,7 +40,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             $fs->ensureDirectoryExists($repoPath);
             $tufDurableStorage = new FileStorage($repoPath);
             // Instantiate TUF library.
-            $this->tufRepo = new Updater($this->composerRepoUrl, [
+            $this->tufRepo = new Updater($repoConfig['url'], [
               ['url_prefix' => $tufConfig['url']]
             ], $tufDurableStorage);
         } else {
@@ -128,191 +51,42 @@ class TufValidatedComposerRepository extends ComposerRepository
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function loadRootServerFile()
     {
-        if (!$this->isValidated) {
-            return parent::loadRootServerFile();
+        // If we are using TUF, fetch the latest secure metadata for the
+        // Composer package metadata.
+        if ($this->tufRepo) {
+            try {
+                $this->tufRepo->refresh();
+            } catch (TufException $e) {
+                throw new RepositorySecurityException('TUF secure error: ' . $e->getMessage(), $e->getCode(), $e);
+            }
         }
-
-        if (null !== $this->tufValidatedRootData) {
-            return $this->tufValidatedRootData;
-        }
-
-        $jsonUrlParts = parse_url($this->composerRepoUrl);
-
-        if (isset($jsonUrlParts['path']) && false !== strpos($jsonUrlParts['path'], '.json')) {
-            $jsonUrl = $this->composerRepoUrl;
-        } else {
-            $jsonUrl = $this->composerRepoUrl . '/root.json';
-        }
-
-        try {
-            $this->tufRepo->refresh();
-        } catch (TufException $e) {
-            throw new RepositorySecurityException('TUF secure error: ' . $e->getMessage(), $e->getCode(), $e);
-        }
-
-        // fetchFile() will throw a RepositorySecurityException if the hash doesn't match.
-        $data = $this->fetchFile($jsonUrl, 'root.json');
-
-        if (!empty($data['providers-url'])) {
-            $this->providersUrl = $this->canonicalizeUrl($data['providers-url']);
-            $this->hasProviders = true;
-        }
-
-        if (!empty($data['list'])) {
-            $this->listUrl = $this->canonicalizeUrl($data['list']);
-        }
-
-        if (!empty($data['providers']) || !empty($data['providers-includes'])) {
-            $this->hasProviders = true;
-        }
-
-        if (!empty($data['providers-api'])) {
-            $this->providersApiUrl = $this->canonicalizeUrl($data['providers-api']);
-        }
-
-        return $this->tufValidatedRootData = $data;
+        return parent::loadRootServerFile();
     }
 
     /**
-     * Reimplementation of parent::fetchFile that obtains files as validated TUF targets.
-     *
-     * @param string $filename
-     * @param string $cacheKey
-     * @param string $sha256
-     * @param bool $storeLastModifiedTime
-     * @return array
-     * @throws RepositorySecurityException
+     * {@inheritDoc}
      */
     protected function fetchFile($filename, $cacheKey = null, $sha256 = null, $storeLastModifiedTime = false)
     {
-        if (!$this->isValidated) {
-            return parent::fetchFile($filename, $cacheKey, $sha256, $storeLastModifiedTime);
-        }
-
-        // url-encode $ signs in URLs as bad proxies choke on them
-        if (($pos = strpos($filename, '$')) && preg_match('{^https?://}i', $filename)) {
-            $filename = substr($filename, 0, $pos) . '%24' . substr($filename, $pos + 1);
-        }
-
-        $retries = 3;
-        while ($retries--) {
+        if ($this->tufRepo) {
+            $tufTarget = ltrim(parse_url($filename, PHP_URL_PATH), '/');
             try {
-                if ($this->eventDispatcher) {
-                    $preFileDownloadEvent = new PreFileDownloadEvent(PluginEvents::PRE_FILE_DOWNLOAD, $this->httpDownloader, $filename, 'metadata');
-                    $this->eventDispatcher->dispatch($preFileDownloadEvent->getName(), $preFileDownloadEvent);
-                    $filename = $preFileDownloadEvent->getProcessedUrl();
-                }
-
-                $tufTarget = ltrim(parse_url($filename, PHP_URL_PATH), '/');
                 $tufTargetInfo = $this->tufRepo->getOneValidTargetInfo($tufTarget);
-                // @todo: Investigate whether all $sha256 hashes, when provided, are trusted. Skip TUF if so.
-                if ($sha256 != null && $sha256 != $tufTargetInfo['hashes']['sha256']) {
-                    throw new RepositorySecurityException('TUF secure error: disagreement between TUF and Composer repositories on expected hash of ' . $tufTarget);
-                }
-                $sha256 = $tufTargetInfo['hashes']['sha256'];
-                // @todo: Add expected length to the get options, implement download abort by length.
-                // See CURLOPT_PROGRESSFUNCTION/CURLOPT_WRITEFUNCTION.
-                $response = $this->httpDownloader->get($filename, $this->options);
-                $json = $response->getBody();
-                if ($sha256 !== hash('sha256', $json)) {
-                    if ($retries) {
-                        usleep(100000);
-
-                        continue;
-                    }
-
-                    // TODO use scarier wording once we know for sure it doesn't do false positives anymore
-                    throw new RepositorySecurityException('The contents of '.$filename.' do not match its signature. This could indicate a man-in-the-middle attack or e.g. antivirus software corrupting files. Try running composer again and report this if you think it is a mistake.');
-                }
-
-                $data = $response->decodeJson();
-                HttpDownloader::outputWarnings($this->io, $this->composerRepoUrl, $data);
-
-                if ($cacheKey && !$this->cache->isReadOnly()) {
-                    if ($storeLastModifiedTime) {
-                        $lastModifiedDate = $response->getHeader('last-modified');
-                        if ($lastModifiedDate) {
-                            $data['last-modified'] = $lastModifiedDate;
-                            $json = json_encode($data);
-                        }
-                    }
-                    $this->cache->write($cacheKey, $json);
-                }
-
-                $response->collect();
-
-                break;
-            } catch (\Exception $e) {
-                if ($e instanceof \LogicException) {
-                    throw $e;
-                }
-
-                if ($e instanceof TransportException && $e->getStatusCode() === 404) {
-                    throw $e;
-                }
-
-                if ($retries) {
-                    // Try http if we were trying https.
-                    $this->downgradeToHttp();
-                    if ($this->allowSslDowngrade) {
-                        $filename = str_replace('https://', 'http://', $filename);
-                    }
-
-                    usleep(100000);
-                    continue;
-                }
-
-                if ($e instanceof TufException) {
-                    $e = new RepositorySecurityException('TUF secure error: ' . $e->getMessage(), $e->getCode(), $e);
-                }
-
-                if ($e instanceof RepositorySecurityException) {
-                    throw $e;
-                }
-
-                if ($cacheKey && ($contents = $this->cache->read($cacheKey))) {
-                    if (!$this->degradedMode) {
-                        $this->io->writeError('<warning>' . $this->composerRepoUrl . ' could not be fully loaded (' . $e->getMessage() . '), package information was loaded from the local cache and may be out of date</warning>');
-                    }
-                    $this->degradedMode = true;
-                    $data = JsonFile::parseJson($contents, $this->cache->getRoot() . $cacheKey);
-
-                    break;
-                }
-
-                throw $e;
-            }
-        }
-        if (!isset($data)) {
-            throw new \LogicException("TufValidatedComposerRepository: Undefined \$data. Please report at https://github.com/php-tuf/composer-integration/issues/new.");
-        }
-
-        return $data;
-    }
-
-    /**
-     * Reimplementation of parent::canonicalizeUrl(), whose visibility is private.
-     */
-    protected function canonicalizeUrl($url)
-    {
-        if ('/' === $url[0]) {
-            if (preg_match('{^[^:]++://[^/]*+}', $this->composerRepoUrl, $matches)) {
-                return $matches[0] . $url;
+            } catch (TufException $e) {
+                throw new RepositorySecurityException('TUF secure error: ' . $e->getMessage(), $e->getCode(), $e);
             }
 
-            return $this->composerRepoUrl;
+            // @todo: Investigate whether all $sha256 hashes, when provided, are trusted. Skip TUF if so.
+            if ($sha256 != null && $sha256 != $tufTargetInfo['hashes']['sha256']) {
+                throw new RepositorySecurityException('TUF secure error: disagreement between TUF and Composer repositories on expected hash of ' . $tufTarget);
+            }
+            $sha256 = $tufTargetInfo['hashes']['sha256'];
         }
-
-        return $url;
-    }
-
-    protected function downgradeToHttp()
-    {
-        if ($this->allowSslDowngrade) {
-            $this->composerRepoUrl = str_replace("https://", "http://", $this->composerRepoUrl);
-        }
-        // @todo (php-tuf): Implement method for application to request that TUF switch to http.
+        return parent::fetchFile($filename, $cacheKey, $sha256, $storeLastModifiedTime);
     }
 }


### PR DESCRIPTION
This plugin currently does a lot of digging around in Composer's internals and copy-pastes a huge amount of code from ComposerRepository. This branch proposes to remove as much of that as possible:

* Use only public methods to get and set instantiated repositories, and their TUF-validated counterparts, in the repository manager.
* Refresh TUF metadata before fetching the root server file, and then delegate everything else to ComposerRepository.
* Use TUF to get the SHA256 hash in fetchFile(), then delegate everything else to ComposerRepository.

It's entirely possible that I missed something here, but this is what I've come up with based on my research into how TUF might be consumed by another package, and what Composer's API offers.