### PR TITLE
Properly instantiate TUF when constructing a repository

### DIFF
--- a/src/Repository/TufValidatedComposerRepository.php
+++ b/src/Repository/TufValidatedComposerRepository.php
@@ -9,7 +9,9 @@ use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositorySecurityException;
 use Composer\Util\Filesystem;
 use Composer\Util\HttpDownloader;
+use GuzzleHttp\Client;
 use Tuf\Client\DurableStorage\FileStorage;
+use Tuf\Client\GuzzleFileFetcher;
 use Tuf\Client\Updater;
 use Tuf\Exception\TufException;
 
@@ -42,7 +44,10 @@ class TufValidatedComposerRepository extends ComposerRepository
             $fs->ensureDirectoryExists($repoPath);
             $tufDurableStorage = new FileStorage($repoPath);
             // Instantiate TUF library.
-            $this->tufRepo = new Updater($repoConfig['url'], [
+            $client = new Client([
+              'base_uri' => $tufConfig['url'],
+            ]);
+            $this->tufRepo = new Updater(new GuzzleFileFetcher($client), [
               ['url_prefix' => $tufConfig['url']]
             ], $tufDurableStorage);
         } else {


### PR DESCRIPTION
Right now, TufValidatedComposerRepository::__construct() incorrectly creates a new instance of the Updater class, which causes a fatal error. Let's fix it so it doesn't do that.