### PR TITLE
Ensure test project can be installed on CI

### DIFF
--- a/.github/workflows/build-fixture.yml
+++ b/.github/workflows/build-fixture.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Generate fixture
         run: |
           pipenv run python generate.py
+          cp ./metadata/root.json ./test-project/tuf-root.json
       - name: Install PHP and Composer 2
         uses: shivammathur/setup-php@v2
         with:
@@ -32,5 +33,5 @@ jobs:
       - name: Start PHP server
         run: 'php -S localhost:8080 &'
       - name: Install test project dependencies
-        run: 'composer require php-tuf/composer-integration:dev-${{ env.GITHUB_HEAD_REF }}'
+        run: 'composer require php-tuf/composer-integration'
         working-directory: ./fixtures/test-project


### PR DESCRIPTION
Right now, CI builds fail because the test project cannot be installed. We'll need to fix this in order to have proper tests of this plugin.