### PR TITLE
Do not allow the updater to be passed in configuration

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -39,13 +39,6 @@ class TufValidatedComposerRepository extends ComposerRepository
     private $updater;
 
     /**
-     * A TUF updater to use in unit testing.
-     *
-     * @var ComposerCompatibleUpdater
-     */
-    public static $_updater;
-
-    /**
      * {@inheritDoc}
      */
     public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
@@ -77,12 +70,11 @@ class TufValidatedComposerRepository extends ComposerRepository
 
             // For unit testing purposes, allow the updater instance to be provided
             // by calling code before this object is created.
-            $this->updater = static::$_updater ?: new ComposerCompatibleUpdater(
+            $this->updater = new ComposerCompatibleUpdater(
                 GuzzleFileFetcher::createFromUri($url),
                 [],
                 new FileStorage($repoPath)
             );
-            static::$_updater = null;
 
             // The Python tool (which generates the server-side TUF repository) will
             // put all signed files into /targets, so ensure that all downloads are

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -39,6 +39,13 @@ class TufValidatedComposerRepository extends ComposerRepository
     private $updater;
 
     /**
+     * A TUF updater to use in unit testing.
+     *
+     * @var ComposerCompatibleUpdater
+     */
+    public static $_updater;
+
+    /**
      * {@inheritDoc}
      */
     public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
@@ -68,14 +75,14 @@ class TufValidatedComposerRepository extends ComposerRepository
                 }
             }
 
-            // For unit testing purposes, allow the updater instance to be passed in
-            // the plugin configuration.
-            if (isset($repoConfig['tuf']['_updater'])) {
-                $this->updater = $repoConfig['tuf']['_updater'];
-            } else {
-                $fetcher = GuzzleFileFetcher::createFromUri($url);
-                $this->updater = new ComposerCompatibleUpdater($fetcher, [], new FileStorage($repoPath));
-            }
+            // For unit testing purposes, allow the updater instance to be provided
+            // by calling code before this object is created.
+            $this->updater = static::$_updater ?: new ComposerCompatibleUpdater(
+                GuzzleFileFetcher::createFromUri($url),
+                [],
+                new FileStorage($repoPath)
+            );
+            static::$_updater = null;
 
             // The Python tool (which generates the server-side TUF repository) will
             // put all signed files into /targets, so ensure that all downloads are

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -70,12 +70,12 @@ class ApiTest extends TestCase
             ->willThrow('\Tuf\Exception\NotFoundException')
             ->shouldBeCalled();
 
+        TufValidatedComposerRepository::$_updater = $updater->reveal();
         $repository = $this->composer->getRepositoryManager()
             ->createRepository('composer', [
                 'url' => 'https://example.com',
                 'tuf' => [
                     'root' => __DIR__ . '/../test-project/root.json',
-                    '_updater' => $updater->reveal(),
                 ],
             ]);
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -70,7 +70,6 @@ class ApiTest extends TestCase
             ->willThrow('\Tuf\Exception\NotFoundException')
             ->shouldBeCalled();
 
-        TufValidatedComposerRepository::$_updater = $updater->reveal();
         $repository = $this->composer->getRepositoryManager()
             ->createRepository('composer', [
                 'url' => 'https://example.com',
@@ -78,6 +77,10 @@ class ApiTest extends TestCase
                     'root' => __DIR__ . '/../test-project/root.json',
                 ],
             ]);
+        $reflector = new \ReflectionObject($repository);
+        $property = $reflector->getProperty('updater');
+        $property->setAccessible(true);
+        $property->setValue($repository, $updater->reveal());
 
         // If the target length is known, it should end up in the transport options.
         $event = new PreFileDownloadEvent(


### PR DESCRIPTION
Over in #18, @tedbow pointed out that it seems potentially dangerous, in some situations, to allow TufValidatedComposerRepository to accept its dependencies in configuration. For unit testing, though, it's necessary to be able to mock things like the updater. Since everything happens in the repository constructor, it makes sense to just use reflection in our tests to set the private property value.