### PR TITLE
Use a magic naming scheme to locate the initial root metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ which will be searched for in this order:
 
 1. A SHA-256 hash of the full repository URL. For example, if the repository URL is `http://repo.example.net/composer`,
    the JSON file can be named `d82cfa7a5a4ba36bd2bcc9d3f7b24bdddbe1209b71ebebaeebc59f6f0ea48792.json`.
-2. The host name of the repository. To continue the previous example, the JSON file can be named `repo.example.net`.
+2. The host name of the repository. To continue the previous example, the JSON file can be named 
+   `repo.example.net.json`.
 
 All root key files must be stored in a directory called`tuf`, adjacent to the project's `composer.json` file.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ The plugin examines `composer` type repositories. For any that contain an additi
 during package discovery and download operations, validating that the repository and package are not being tampered
 with.
 
+In accordance with the [TUF specification](https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#5-detailed-workflows),
+projects using this plugin must supply a set of trusted keys for each repository they want to protect with TUF. Each
+TUF-protected repository should provide a JSON file named for the repository URL, with non-alphanumeric characters
+replaced by a single period. For example, if the repository URL is `https://repo.example.net:1234/packages`, then the
+key file should be called `https.repo.example.net.1234.packages.json`. All key files must be stored in a directory
+called`tuf`, adjacent to the project's `composer.json` file.
+
 The TUF repository must track the Composer repository, signing new versions of packages as they are released as well as
 the Composer package metadata for them.
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ with.
 
 In accordance with the [TUF specification](https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#5-detailed-workflows),
 projects using this plugin must supply a set of trusted keys for each repository they want to protect with TUF. Each
-TUF-protected repository should provide a JSON file named for the repository URL, with non-alphanumeric characters
-replaced by a single period. For example, if the repository URL is `https://repo.example.net:1234/packages`, then the
-key file should be called `https.repo.example.net.1234.packages.json`. All key files must be stored in a directory
-called`tuf`, adjacent to the project's `composer.json` file.
+TUF-protected repository should provide a JSON file with its root keys. The file may be named in one of a few ways,
+which will be searched for in this order:
+
+1. A SHA-256 hash of the full repository URL. For example, if the repository URL is `http://repo.example.net/composer`,
+   the JSON file can be named `d82cfa7a5a4ba36bd2bcc9d3f7b24bdddbe1209b71ebebaeebc59f6f0ea48792.json`.
+2. The host name of the repository. To continue the previous example, the JSON file can be named `repo.example.net`.
+
+All root key files must be stored in a directory called`tuf`, adjacent to the project's `composer.json` file.
 
 The TUF repository must track the Composer repository, signing new versions of packages as they are released as well as
 the Composer package metadata for them.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ which will be searched for in this order:
 2. The host name of the repository. To continue the previous example, the JSON file can be named 
    `repo.example.net.json`.
 
-All root key files must be stored in a directory called`tuf`, adjacent to the project's `composer.json` file.
+All root key files must be stored in a directory called `tuf`, adjacent to the project's `composer.json` file.
 
 The TUF repository must track the Composer repository, signing new versions of packages as they are released as well as
 the Composer package metadata for them.

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
             "rm -r -f metadata",
             "pipenv run python generate.py",
             "mkdir ./test-project/tuf",
-            "cp -f ./metadata/root.json ./test-project/tuf/http.localhost.8080.json"
+            "cp -f ./metadata/root.json ./test-project/tuf/localhost.json"
         ],
         "post-install-cmd": "@post-update-cmd",
         "post-update-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
             "pipenv install",
             "rm -r -f metadata",
             "pipenv run python generate.py",
-            "cp -f ./metadata/root.json ./test-project"
+            "mkdir ./test-project/tuf",
+            "cp -f ./metadata/root.json ./test-project/tuf/http.localhost.8080.json"
         ],
         "post-install-cmd": "@post-update-cmd",
         "post-update-cmd": [

--- a/src/ComposerFileStorage.php
+++ b/src/ComposerFileStorage.php
@@ -51,7 +51,10 @@ class ComposerFileStorage extends FileStorage
      */
     public static function create(string $url, Config $config): self
     {
-        $basePath = static::basePath($config) . DIRECTORY_SEPARATOR . hash('sha256', $url);
+        $basePath = implode(DIRECTORY_SEPARATOR, [
+            static::basePath($config),
+            preg_replace('/[^[:alnum:]\.]/', '-', $url),
+        ]);
         return new static($basePath);
     }
 }

--- a/src/ComposerFileStorage.php
+++ b/src/ComposerFileStorage.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tuf\ComposerIntegration;
+
+use Composer\Config;
+use Composer\Util\Filesystem;
+use Tuf\Client\DurableStorage\FileStorage;
+
+/**
+ * Defines storage for the PHP-TUF metadata of a repository in a Composer project.
+ */
+class ComposerFileStorage extends FileStorage
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(string $basePath)
+    {
+        (new Filesystem())->ensureDirectoryExists($basePath);
+        parent::__construct($basePath);
+    }
+
+    /**
+     * Returns the base path where data for all repositories is stored.
+     *
+     * @param Config $config
+     *   The current Composer configuration.
+     *
+     * @return string
+     *   The base path where data is stored.
+     */
+    public static function basePath(Config $config): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [
+            rtrim($config->get('vendor-dir'), DIRECTORY_SEPARATOR),
+            'composer',
+            'tuf',
+        ]);
+    }
+
+    /**
+     * Creates a storage object for a specific repository.
+     *
+     * @param string $url
+     *   The repository URL.
+     * @param Config $config
+     *   The current Composer configuration.
+     *
+     * @return static
+     *   The storage object.
+     */
+    public static function create(string $url, Config $config): self
+    {
+        $basePath = implode(DIRECTORY_SEPARATOR, [
+            static::basePath($config),
+            preg_replace('/[^[:alnum:]\.]/', '-', $url),
+        ]);
+        return new static($basePath);
+    }
+}

--- a/src/ComposerFileStorage.php
+++ b/src/ComposerFileStorage.php
@@ -51,10 +51,7 @@ class ComposerFileStorage extends FileStorage
      */
     public static function create(string $url, Config $config): self
     {
-        $basePath = implode(DIRECTORY_SEPARATOR, [
-            static::basePath($config),
-            preg_replace('/[^[:alnum:]\.]/', '-', $url),
-        ]);
+        $basePath = static::basePath($config) . DIRECTORY_SEPARATOR . hash('sha256', $url);
         return new static($basePath);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,7 +3,6 @@
 namespace Tuf\ComposerIntegration;
 
 use Composer\Composer;
-use Composer\Config;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
@@ -177,29 +176,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     public function uninstall(Composer $composer, IOInterface $io)
     {
-        $path = static::getStoragePath($composer->getConfig());
+        $path = ComposerFileStorage::basePath($composer->getConfig());
         $io->info("Deleting TUF data in $path");
 
         $fs = new Filesystem();
         $fs->removeDirectoryPhp($path);
-    }
-
-    /**
-     * Returns the base path where TUF data will be persisted.
-     *
-     * @param Config $config
-     *   The Composer configuration.
-     *
-     * @return string
-     *   The base path where TUF data will be persisted.
-     */
-    public static function getStoragePath(Config $config): string
-    {
-        return implode(DIRECTORY_SEPARATOR, [
-            rtrim($config->get('vendor-dir'), DIRECTORY_SEPARATOR),
-            'composer',
-            'tuf',
-        ]);
     }
 
     /**

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -116,14 +116,13 @@ class TufValidatedComposerRepository extends ComposerRepository
         // to the active composer.json.
         $searchDir = dirname($config->getConfigSource()->getName()) . DIRECTORY_SEPARATOR . 'tuf';
 
-        $map = function (string $candidate) use ($searchDir): string
-        {
-            return $searchDir . DIRECTORY_SEPARATOR . $candidate . '.json';
-        };
-        $candidates = array_map($map, $candidates);
-        $candidates = array_filter($candidates, 'file_exists');
-
-        return reset($candidates) ?: null;
+        foreach ($candidates as $candidate) {
+            $location = $searchDir . DIRECTORY_SEPARATOR . $candidate . '.json';
+            if (file_exists($location)) {
+                return $location;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -79,22 +79,22 @@ class TufValidatedComposerRepository extends ComposerRepository
     private function initializeStorage(string $url, Config $config): string
     {
         // Use the repository URL to derive an identifier. We expect the initial
-        // root metadata to be named as IDENTIFIER.json, and this identifier will
-        // also be the name of the durable storage directory.
+        // root metadata to be named IDENTIFIER.json. The identifier will also be
+        // used as the name of the durable storage directory.
         $repoKey = preg_replace('/[^[:alnum:]\.]+/', '.', $url);
 
         $storagePath = Plugin::getStoragePath($config) . DIRECTORY_SEPARATOR . $repoKey;
         $fs = new Filesystem();
         $fs->ensureDirectoryExists($storagePath);
 
-        // If the durable storage directory doesn't yet have root metadata, copy
+        // If the durable storage directory doesn't have any root metadata, copy
         // the initial root metadata into it.
         $rootMetadataPath = "$storagePath/root.json";
         if (!file_exists($rootMetadataPath)) {
-            //  We expect the initial root metadata to be in a directory
-            // called `tuf`, adjacent to the active composer.json.
+            // We expect the initial root metadata to be in a directory called `tuf`,
+            // adjacent to the active composer.json.
             $initialRootMetadataPath = implode(DIRECTORY_SEPARATOR, [
-                // This is the directory which contains the active composer.json.
+                // Determine the directory containing the active composer.json.
                 dirname($config->getConfigSource()->getName()),
                 'tuf',
                 $repoKey,

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -43,7 +43,7 @@ class TufValidatedComposerRepository extends ComposerRepository
      */
     public function __construct(array $repoConfig, IOInterface $io, Config $config, HttpDownloader $httpDownloader, EventDispatcher $eventDispatcher = null)
     {
-        $url = $repoConfig['url'];
+        $url = rtrim($repoConfig['url'], '/');
 
         if (isset($repoConfig['tuf'])) {
             $repoKey = preg_replace('/[^[:alnum:]\.]+/', '.', $url);
@@ -79,7 +79,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             // The Python tool (which generates the server-side TUF repository) will
             // put all signed files into /targets, so ensure that all downloads are
             // prefixed with that.
-            $repoConfig['url'] .= '/targets';
+            $repoConfig['url'] .= "$url/targets";
         } else {
             // @todo Usability assessment. Should we output this for other repo types, or not at all?
             $io->warning("Authenticity of packages from $url are not verified by TUF.");

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -72,7 +72,7 @@ class TufValidatedComposerRepository extends ComposerRepository
      * @return \ArrayAccess
      *   A durable storage object for this repository's TUF data.
      *
-     * @throws \DomainException
+     * @throws \RuntimeException
      *   If not root metadata could be found for this repository.
      */
     private function initializeStorage(string $url, Config $config): \ArrayAccess
@@ -86,7 +86,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             if ($initialRootMetadataPath) {
                 $storage['root.json'] = file_get_contents($initialRootMetadataPath);
             } else {
-                throw new \DomainException("No TUF root metadata was found for repository $url.");
+                throw new \RuntimeException("No TUF root metadata was found for repository $url.");
             }
         }
         return $storage;

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -79,7 +79,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             // The Python tool (which generates the server-side TUF repository) will
             // put all signed files into /targets, so ensure that all downloads are
             // prefixed with that.
-            $repoConfig['url'] .= "$url/targets";
+            $repoConfig['url'] = "$url/targets";
         } else {
             // @todo Usability assessment. Should we output this for other repo types, or not at all?
             $io->warning("Authenticity of packages from $url are not verified by TUF.");

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -3,7 +3,6 @@
 namespace Tuf\ComposerIntegration;
 
 use Composer\Config;
-use Composer\Downloader\FilesystemException;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -8,11 +8,9 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Repository\ComposerRepository;
-use Composer\Util\Filesystem;
 use Composer\Util\Http\Response;
 use Composer\Util\HttpDownloader;
 use GuzzleHttp\Psr7\Utils;
-use Tuf\Client\DurableStorage\FileStorage;
 use Tuf\Client\GuzzleFileFetcher;
 use Tuf\Exception\NotFoundException;
 

--- a/test-project/.gitignore
+++ b/test-project/.gitignore
@@ -1,3 +1,3 @@
 /composer.lock
-/root.json
+/tuf
 /vendor

--- a/test-project/composer.json
+++ b/test-project/composer.json
@@ -6,9 +6,7 @@
         {
             "type": "composer",
             "url": "http://localhost:8080",
-            "tuf": {
-                "root": "root.json"
-            }
+            "tuf": true
         },
         {
             "type": "path",

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -63,6 +63,8 @@ class ApiTest extends TestCase
      */
     public function testPreFileDownload(): void
     {
+        $url = 'http://localhost:8080';
+
         $updater = $this->prophesize('\Tuf\ComposerIntegration\ComposerCompatibleUpdater');
         $updater->getLength('packages.json')
             ->willReturn(1024)
@@ -73,7 +75,7 @@ class ApiTest extends TestCase
 
         $repository = $this->composer->getRepositoryManager()
             ->createRepository('composer', [
-                'url' => 'http://localhost:8080',
+                'url' => $url,
                 'tuf' => [
                     '_updater' => $updater->reveal(),
                 ],
@@ -83,7 +85,7 @@ class ApiTest extends TestCase
         $event = new PreFileDownloadEvent(
             PluginEvents::PRE_FILE_DOWNLOAD,
             $this->composer->getLoop()->getHttpDownloader(),
-            'http://localhost:8080/targets/packages.json',
+            "$url/targets/packages.json",
             'metadata',
             [
                 'repository' => $repository,
@@ -98,7 +100,7 @@ class ApiTest extends TestCase
         $event = new PreFileDownloadEvent(
             PluginEvents::PRE_FILE_DOWNLOAD,
             $this->composer->getLoop()->getHttpDownloader(),
-            'http://localhost:8080/targets/bogus.json',
+            "$url/targets/bogus.json",
             'metadata',
             [
                 'repository' => $repository,

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -43,8 +43,9 @@ class ApiTest extends TestCase
         parent::setUp();
         $this->plugin = new Plugin();
 
+        $dir = __DIR__ . '/../test-project';
         $factory = new Factory();
-        $this->composer = $factory->createComposer(new NullIO(), []);
+        $this->composer = $factory->createComposer(new NullIO(), "$dir/composer.json", false, $dir);
         $this->composer->getPluginManager()->addPlugin($this->plugin);
     }
 
@@ -72,9 +73,8 @@ class ApiTest extends TestCase
 
         $repository = $this->composer->getRepositoryManager()
             ->createRepository('composer', [
-                'url' => 'https://example.com',
+                'url' => 'http://localhost:8080',
                 'tuf' => [
-                    'root' => __DIR__ . '/../test-project/root.json',
                     '_updater' => $updater->reveal(),
                 ],
             ]);
@@ -83,7 +83,7 @@ class ApiTest extends TestCase
         $event = new PreFileDownloadEvent(
             PluginEvents::PRE_FILE_DOWNLOAD,
             $this->composer->getLoop()->getHttpDownloader(),
-            'https://example.com/targets/packages.json',
+            'http://localhost:8080/targets/packages.json',
             'metadata',
             [
                 'repository' => $repository,
@@ -98,7 +98,7 @@ class ApiTest extends TestCase
         $event = new PreFileDownloadEvent(
             PluginEvents::PRE_FILE_DOWNLOAD,
             $this->composer->getLoop()->getHttpDownloader(),
-            'https://example.com/targets/bogus.json',
+            'http://localhost:8080/targets/bogus.json',
             'metadata',
             [
                 'repository' => $repository,


### PR DESCRIPTION
This PR implements the idea @davidstrauss came up with in #18: to use a magic naming scheme to locate the initial root metadata.

The idea is that we expect the initial root metadata to be named after the repository URL, with the various components separated by a period. So `http://localhost:8080` becomes `http.localhost.8080.json`. Subdirectories are considered too, so `https://packages.drupal.org/8` would become `https.packages.drupal.org.8.json`. The file is expected to be in a `tuf` directory next to the active `composer.json`.

Honestly, I like this approach better than #18. We could use the Drupal scaffold plugin to automatically ship this file into the correct location, and the magic naming is (IMHO) pretty easy to grok. This doesn't need to call out to the Internet, so it's safer, and it actually _removes_ configuration from `composer.json`, keeping it simple and self-sufficient.