### PR TITLE
Make ApiTest clean up its vendor directory

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -73,7 +73,7 @@ class TufValidatedComposerRepository extends ComposerRepository
      *   A durable storage object for this repository's TUF data.
      *
      * @throws \RuntimeException
-     *   If not root metadata could be found for this repository.
+     *   If no root metadata could be found for this repository.
      */
     private function initializeStorage(string $url, Config $config): \ArrayAccess
     {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -7,6 +7,7 @@ use Composer\IO\NullIO;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Repository\ComposerRepository;
+use Composer\Util\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\ComposerIntegration\Plugin;
@@ -55,6 +56,8 @@ class ApiTest extends TestCase
     protected function tearDown(): void
     {
         $this->composer->getPluginManager()->uninstallPlugin($this->plugin);
+        (new Filesystem())
+            ->removeDirectory(__DIR__ . '/vendor');
         parent::tearDown();
     }
 


### PR DESCRIPTION
Right now, ApiTest leaves an empty `vendor` directory behind. It should remove that on tear-down.