### PR TITLE
Add test coverage of post-file download event handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
             "pipenv install",
             "rm -r -f metadata",
             "pipenv run python generate.py",
-            "mkdir ./test-project/tuf",
+            "mkdir -p ./test-project/tuf",
             "cp -f ./metadata/root.json ./test-project/tuf/localhost.json"
         ],
         "post-install-cmd": "@post-update-cmd",


### PR DESCRIPTION
Just what it says. We don't have any unit test coverage of the post-download event handlers, so let's add some.