### PR TITLE
Add void type hint to TufValidatedComposerRepository::configurePackageTransportOptions()

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -128,7 +128,7 @@ class TufValidatedComposerRepository extends ComposerRepository
     /**
      * {@inheritDoc}
      */
-    protected function configurePackageTransportOptions(PackageInterface $package)
+    protected function configurePackageTransportOptions(PackageInterface $package): void
     {
         parent::configurePackageTransportOptions($package);
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -128,7 +128,7 @@ class ApiTest extends TestCase
                 ];
             }
 
-            public function configurePackageTransportOptions(PackageInterface $package)
+            public function configurePackageTransportOptions(PackageInterface $package): void
             {
                 parent::configurePackageTransportOptions($package);
             }


### PR DESCRIPTION
[Our tests are failing](https://github.com/php-tuf/composer-integration/runs/5820113883?check_suite_focus=true#step:9:14) because TufValidatedComposerRepository::configurePackageTransportOptions() doesn't have a `void` return type hint.

In Composer 2.1.0, [the parent method doesn't have it either](https://github.com/composer/composer/blob/2.1.0/src/Composer/Repository/ComposerRepository.php#L514). The tests are failing because [Composer 2.3.0 and up does have the type hint](https://github.com/composer/composer/blob/2.3.0/src/Composer/Repository/ComposerRepository.php#L668). So right now, we're compatible with Composer 2.1 and 2.2, but not 2.3 and later.

Luckily, [in PHP 7.2 and later, there is partial covariance support](https://www.php.net/manual/en/language.oop5.variance.php) that allows the child method to have the type hint, even if the parent method doesn't. [I tried it and it works.](https://3v4l.org/3QRTi#v7.2.0)

Since we're targeting PHP 7.3 (for Drupal 9 compatibility) and [allowing PHP 7.2 as the bare minimum](https://github.com/php-tuf/php-tuf/blob/main/composer.json#L14) (presumably because of libsodium), I think it's safe for us to fix this by adding the `void` return type hint to TufValidatedComposerRepository::configurePackageTransportOptions().