### PR TITLE
Do not allow test project to interact with the internet

### DIFF
--- a/test-project/composer.json
+++ b/test-project/composer.json
@@ -2,21 +2,18 @@
     "name": "php-tuf/example-composer-project",
     "description": "Demo of a secured root composer.json",
     "type": "project",
-    "repositories": [
-        {
+    "repositories": {
+        "fixture": {
             "type": "composer",
             "url": "http://localhost:8080",
             "tuf": true
         },
-        {
+        "plugin": {
             "type": "path",
             "url": "../"
         },
-        {
-            "type": "vcs",
-            "url": "https://github.com/php-tuf/php-tuf.git"
-        }
-    ],
+        "packagist.org": false
+    },
     "minimum-stability": "dev",
     "config": {
         "secure-http": false

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -55,7 +55,7 @@ class ComposerCommandsTest extends TestCase
         }
         $destination = static::$projectDir . '/vendor.json';
         file_put_contents($destination, json_encode($vendor, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        static::composer('config', 'repo.vendor', "file://$destination");
+        static::composer("config repo.vendor composer file://$destination");
 
         // Install the plugin.
         static::composer('require', 'php-tuf/composer-integration');
@@ -74,7 +74,7 @@ class ComposerCommandsTest extends TestCase
 
         // Remove the repository of installed vendor dependencies created by
         // ::setUpBeforeClass().
-        static::composer('config', '--unset', 'repo.vendor');
+        static::composer("config --unset repo.vendor");
         unlink(static::$projectDir . '/vendor.json');
 
         parent::tearDownAfterClass();

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -55,7 +55,7 @@ class ComposerCommandsTest extends TestCase
         }
         $destination = static::$projectDir . '/vendor.json';
         file_put_contents($destination, json_encode($vendor, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        static::composer("config repo.vendor composer file://$destination");
+        static::composer('config', 'repo.vendor', 'composer', 'file://' . $destination);
 
         // Install the plugin.
         static::composer('require', 'php-tuf/composer-integration');
@@ -74,7 +74,7 @@ class ComposerCommandsTest extends TestCase
 
         // Remove the repository of installed vendor dependencies created by
         // ::setUpBeforeClass().
-        static::composer("config --unset repo.vendor");
+        static::composer('config', '--unset', 'repo.vendor');
         unlink(static::$projectDir . '/vendor.json');
 
         parent::tearDownAfterClass();


### PR DESCRIPTION
Our test fixture, which is in the `test-project` directory, currently interacts with the internet (see [the current failure of `ComposerCommandsTest`](https://github.com/php-tuf/composer-integration/runs/5820393610?check_suite_focus=true#step:9:48)). This fixture, and the test, should create a static vendor repository, much like Drupal's build tests do (and which we also implemented for the contributed Automatic Updates module), so that the test never needs to interact with the internet in order to install already-present dependencies.