### PR TITLE
Don't bother mocking the time when generating TUF data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,9 @@ jobs:
           tools: 'composer:v2'
       - name: Install dependencies
         run: 'composer install ${{ env.COMPOSER_FLAGS }}'
-      - name: Build TUF fixture
-        run: 'composer run make-fixture'
       - name: Start PHP server
         run: 'php -S localhost:8080 &'
-      - name: Run tests
+      - name: Build TUF fixture and run tests
         run: 'composer test'
       - name: Check dependencies for known security vulnerabilities
         run: 'composer security'

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,10 @@
             "cp -f ./vendor/php-tuf/php-tuf/Pipfile* .",
             "ln -s -f ./targets/packages.json ."
         ],
-        "test": "phpunit ./tests"
+        "test": [
+            "@composer make-fixture",
+            "phpunit ./tests"
+        ]
     },
     "config": {
         "platform": {

--- a/generate.py
+++ b/generate.py
@@ -5,7 +5,6 @@ import os
 import shutil
 
 from os import path
-from unittest import mock
 
 # This file largely derives from:
 # https://github.com/php-tuf/php-tuf/blob/main/generate_fixtures.py
@@ -21,7 +20,6 @@ def import_keypair(name):
 
     return (public, private)
 
-@mock.patch('time.time', mock.MagicMock(return_value=1577836800))
 def generate_fixture():
     dir = os.getcwd()
 


### PR DESCRIPTION
In php-tuf/php-tuf, [we mock the current time when generating test fixtures](https://github.com/php-tuf/php-tuf/blob/main/generate_fixtures.py#L25). This was done by @davidstrauss because, since the fixtures are committed to the repository, there was a need to generate them deterministically so that they'd be consistent over time.

This plugin, however, doesn't have the same need. The fixture(s) are only _ever_ generated for testing and debugging purposes; it's more of a "JIT" approach. Apart from certain targets which are signed by Python TUF, the generated fixture data is not committed to the repository. So there is no benefit to mocking the current time, and indeed it makes tests fail if the mocked time is too far in the past.

So let's just stop mocking the current time when generating fixtures. And in fact, to ensure the generated fixtures don't accidentally end up out-of-date in someone's local environment, let's always regenerate them before tests are run (as part of the `test` script).