### PR TITLE
Remove explicit security check from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,3 @@ jobs:
         run: 'php -S localhost:8080 &'
       - name: Build TUF fixture and run tests
         run: 'composer test'
-      - name: Check dependencies for known security vulnerabilities
-        run: 'composer security'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,5 @@ jobs:
         run: 'php -S localhost:8080 &'
       - name: Build TUF fixture and run tests
         run: 'composer test'
+      - name: Check dependencies for known security vulnerabilities
+        run: 'composer security'

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
             "cp -f ./vendor/php-tuf/php-tuf/Pipfile* .",
             "ln -s -f ./targets/packages.json ."
         ],
+        "security": "@composer update --dry-run roave/security-advisories",
         "test": [
             "@composer make-fixture",
             "phpunit ./tests"


### PR DESCRIPTION
[Tests are currently failing because there is no `composer security` script.](https://github.com/php-tuf/composer-integration/runs/5821399310?check_suite_focus=true#step:9:13)

A look at Roave/SecurityAdvisories reveals that it doesn't have a script by that name. In fact, the package has no executable code at all; it simply is a metapackage that conflicts with anything that has known security issues. Maybe it _had_ a `security` script or command at some point, but it sure doesn't anymore.

So, as per #45, let's add one which does a dry-run update as a check for security advisories, as documented at https://github.com/Roave/SecurityAdvisories. Quoted here for posterity:

> You can manually trigger a version check by using the --dry-run switch on an update while not doing anything. Running composer update --dry-run roave/security-advisories is an effective way to manually trigger a security version check.