### PR TITLE
ApiTest needs to pass the plugin's package info to the plugin manager

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -5,6 +5,7 @@ namespace Tuf\ComposerIntegration\Tests;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Package\CompletePackage;
+use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PostFileDownloadEvent;
@@ -52,7 +53,17 @@ class ApiTest extends TestCase
         $dir = __DIR__ . '/../test-project';
         $factory = new Factory();
         $this->composer = $factory->createComposer(new NullIO(), "$dir/composer.json", false, $dir);
-        $this->composer->getPluginManager()->addPlugin($this->plugin);
+
+        // Composer requires the plugin package to be passed to the plugin manager, so load that from the composer.json
+        // at the root of the repository.
+        $source_package = __DIR__ . '/../composer.json';
+        $this->assertFileIsReadable($source_package);
+        $source_package = file_get_contents($source_package);
+        $source_package = json_decode($source_package, true);
+        // The package loader will throw an exception if no version is defined.
+        $source_package += ['version' => '1.0.0'];
+
+        $this->composer->getPluginManager()->addPlugin($this->plugin, false, (new ArrayLoader())->load($source_package));
     }
 
     /**


### PR DESCRIPTION
ApiTest is raising a deprecation warning because it doesn't pass the plugin's package info to Composer's plugin manager when trying to load the plugin: https://github.com/php-tuf/composer-integration/runs/5822428727?check_suite_focus=true#step:8:44

Although our tests don't fail on this right now, I imagine they will in the future. Let's ensure the test loads the plugin package, and fix this deprecation.