### PR TITLE
The test project must explicitly enable the plugin

### DIFF
--- a/test-project/composer.json
+++ b/test-project/composer.json
@@ -16,6 +16,9 @@
     },
     "minimum-stability": "dev",
     "config": {
+        "allow-plugins": {
+            "php-tuf/composer-integration": true
+        },
         "secure-http": false
     },
     "prefer-stable": true


### PR DESCRIPTION
[As of Composer 2.2, composer.json must explicitly declare the plugins it will allow.](https://getcomposer.org/doc/06-config.md#allow-plugins) This means that our test project needs to explicitly enable `php-tuf/composer-integration`. Although our tests are not failing over this just now, they probably will as of July 2022. So let's get ahead of this and fix it now.