### PR TITLE
Add debugging output to help with testing

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -113,6 +113,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     public function activate(Composer $composer, IOInterface $io)
     {
+        $io->debug('TUF integration enabled.');
+
         // By the time this plugin is activated, several repositories may have
         // already been instantiated, and we need to convert them to
         // TUF-validated repositories. Unfortunately, the repository manager

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -85,12 +85,17 @@ class ComposerCommandsTest extends TestCase
      *
      * @param string ...$command
      *   The arguments to pass to Composer.
+     *
+     * @return Process
+     *   The process object.
      */
-    private static function composer(string ...$command): void
+    private static function composer(string ...$command): Process
     {
         array_unshift($command, __DIR__ . '/../vendor/composer/composer/bin/composer');
         $process = new Process($command, static::$projectDir);
         static::assertSame(0, $process->mustRun()->getExitCode());
+
+        return $process;
     }
 
     /**
@@ -122,7 +127,10 @@ class ComposerCommandsTest extends TestCase
     {
         $package = 'drupal/token';
         $this->assertPackageNotInstalled($package);
-        $this->composer('require', $package, '--with-all-dependencies');
+
+        $process = $this->composer('require', $package, '--with-all-dependencies', '-vvv');
+        $this->assertStringContainsString('TUF integration enabled.', $process->getOutput());
+
         $this->assertPackageInstalled($package);
         $this->composer('remove', $package);
         $this->assertPackageNotInstalled($package);


### PR DESCRIPTION
It was pointed out by @ergonlogic that it is hard to test this plugin end-to-end because it is not very verbose at all. Let's add a lot more debugging-level output (which should be revealed by running Composer with the `-vvv` switch) and assert it's there.