### PR TITLE
ComposerCommandsTest should use the current PHP runtime to execute Composer

### DIFF
--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -88,7 +88,8 @@ class ComposerCommandsTest extends TestCase
      */
     private static function composer(string ...$command): void
     {
-        array_unshift($command, __DIR__ . '/../vendor/composer/composer/bin/composer');
+        // Ensure the current PHP runtime is used to execute Composer.
+        array_unshift($command, PHP_BINARY, __DIR__ . '/../vendor/composer/composer/bin/composer');
         $process = new Process($command, static::$projectDir);
         static::assertSame(0, $process->mustRun()->getExitCode());
     }


### PR DESCRIPTION
In some situations, ComposerCommandsTest might be run with a different version of the PHP interpreter than the Process component uses to execute Composer. Let's ensure they're the same by always prepending the current PHP interpreter (i.e., the `PHP_BINARY` constant) to the Composer command in `ComposerCommandsTest::composer()`.