### PR TITLE
Clean up composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,8 @@
 {
     "name": "php-tuf/composer-integration",
-    "description": "POC. Explorations in securing Composer with php-tuf.",
+    "description": "Proof of concept of securing Composer downloads with PHP-TUF.",
     "type": "composer-plugin",
     "repositories": [
-        {
-            "type": "composer",
-            "url": "https://packagist.org",
-            "tuf-url": "https://whatever.com/tuf"
-        },
         {
             "type": "vcs",
             "url": "https://github.com/php-tuf/php-tuf.git"
@@ -20,16 +15,14 @@
             "email": "mike@mbaynton.com"
         },
         {
-            "name": "Please add/edit over time as appropriate"
+            "name": "Adam Globus-Hoenich",
+            "email": "adam@phenaproxima.net"
         }
     ],
     "minimum-stability": "stable",
     "require": {
         "composer-plugin-api": "^2.1",
         "php-tuf/php-tuf": "dev-main"
-    },
-    "conflict": {
-        "zaporylie/composer-drupal-optimizations": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There are a few changes that should be made in composer.json:

* The plugin description could be clearer.
* There is no need to explicitly define the packagist.org repository.
* I should be one of the authors, seeing as how I wrote this entire thing in its current form :)
* There is no need to conflict with `zaporylie/composer-drupal-optimizations`. Although that plugin minimally supports Composer 2, [it immediately disables itself if Composer 2 is detected](https://github.com/zaporylie/composer-drupal-optimizations/blob/master/src/Plugin.php#L19). Because we are now using Composer's legitimate plugin API instead of hacking into deep parts of it, I don't think there's any benefit to conflicting with the other plugin, especially when it takes the time to shut itself down on Composer 2.