### PR TITLE
Update README to remove warning about Composer 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin seeks to demonstrate adding TUF security to
 
 ## IMPORTANT
 
-This plugin, as well as the PHP-TUF library it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework. Additionally, this plugin requires Composer 2.1 or later, which has not yet been released.
+This plugin, as well as the PHP-TUF library it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework.
 
 This plugin should currently only be used for testing, development and feedback. *Do NOT use in production for secure downloads!!*
 


### PR DESCRIPTION
README currently says that Composer 2.1 hasn't been released. This is no longer the case :)