### PR TITLE
CI workflow needs to authenticate with automatic GitHub token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           php-version: 7.3
           tools: 'composer:v2'
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: 'composer install ${{ env.COMPOSER_FLAGS }}'
       - name: Start PHP server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           php-version: 7.3
           tools: 'composer:v2'
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: 'composer install ${{ env.COMPOSER_FLAGS }}'
       - name: Start PHP server


### PR DESCRIPTION
Right now, we cannot install PHP-TUF in our CI workflow because Composer doesn't have a GitHub token to authenticate with.

GitHub Actions generates an automatic token for us to use, and it's supported by the setup-php action (see https://github.com/shivammathur/setup-php#github-composer-authentication). We just have to start using it.

I don't expect CI to start passing with this change, but it'll get us past the initial roadblock of not being able to install PHP-TUF at all.