### PR TITLE
Run CI workflow every day automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: build
 on:
-  - push
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  schedule:
+    # Run this workflow at 4 AM UTC every day.
+    - cron: '0 4 * * *'
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist --optimize-autoloader"
 jobs:


### PR DESCRIPTION
Just what it says.

We should copy what PHP-TUF does and run this workflow:

* On push to `main`
* On PR pushes targeting `main`
* Every day at stupid o'clock in the morning, UTC