### PR TITLE
Cache Composer directories to speed up CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,15 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v${{ matrix.composer }}
           extensions: sodium, json
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies
         run: |
           composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to https://github.com/shivammathur/setup-php#cache-composer-dependencies, we can speed up workflow runs a bit by caching Composer's downloaded files (this is NOT the same as `vendor`). Let's do exactly that; we now have enough jobs that this kind of optimization makes sense.