### PR TITLE
Use property and return types everywhere

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,12 +22,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @var RepositoryManager
      */
-    private $repositoryManager;
+    private RepositoryManager $repositoryManager;
 
     /**
      * {@inheritDoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             PluginEvents::PRE_FILE_DOWNLOAD => ['preFileDownload', -1000],
@@ -111,7 +111,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public function activate(Composer $composer, IOInterface $io)
+    public function activate(Composer $composer, IOInterface $io): void
     {
         $io->debug('TUF integration enabled.');
 
@@ -176,7 +176,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
         $path = ComposerFileStorage::basePath($composer->getConfig());
         $io->info("Deleting TUF data in $path");
@@ -188,7 +188,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 }

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -31,16 +31,16 @@ class TufValidatedComposerRepository extends ComposerRepository
     /**
      * The TUF updater, if any, for this repository.
      *
-     * @var ComposerCompatibleUpdater
+     * @var ComposerCompatibleUpdater|null
      */
-    private $updater;
+    private ?ComposerCompatibleUpdater $updater;
 
     /**
      * The I/O wrapper.
      *
      * @var IOInterface
      */
-    private $io;
+    private IOInterface $io;
 
     /**
      * {@inheritDoc}

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -33,7 +33,7 @@ class TufValidatedComposerRepository extends ComposerRepository
      *
      * @var ComposerCompatibleUpdater|null
      */
-    private ?ComposerCompatibleUpdater $updater;
+    private ?ComposerCompatibleUpdater $updater = NULL;
 
     /**
      * The I/O wrapper.


### PR DESCRIPTION
We're only supporting PHP 8 and later now, so we should take advantage of property type hints and return type covariance to make typing as explicit as possible.