### PR TITLE
Require Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://github.com/php-tuf/composer-integration/actions/workflows/build.yml/badge.svg)
 
-Experimental Composer plugin marrying Composer 2.1 and later to [PHP-TUF](https://github.com/php-tuf/php-tuf).
+Experimental Composer plugin marrying Composer 2.2 and later to [PHP-TUF](https://github.com/php-tuf/php-tuf).
 
 This plugin seeks to demonstrate adding TUF security to
   * Composer's package discovery process when using Composer v2 package repositories.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ## IMPORTANT
 
-This plugin, as well as the [PHP-TUF library](https://github.com/php-tuf/php-tuf) it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework. Additionally, this plugin requires Composer 2.1 or later, which has not yet been released.
+This plugin, as well as the [PHP-TUF library](https://github.com/php-tuf/php-tuf) it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework. Additionally, this plugin requires Composer 2.2 or later, which has not yet been released.
 
 This plugin should currently only be used for testing, development and feedback. *Do NOT use in production for secure downloads!!*
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "composer-plugin-api": "^2.1",
+        "composer-plugin-api": "^2.2",
         "php-tuf/php-tuf": "dev-main",
         "guzzlehttp/guzzle": "^6.5 || ^7.2"
     },


### PR DESCRIPTION
This addresses #33 by bumping our requirement on Composer's plugin API to ^2.2.