### PR TITLE
Stop passing defunct mirrors array to new Updater

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -55,7 +55,6 @@ class TufValidatedComposerRepository extends ComposerRepository
         if (isset($repoConfig['tuf'])) {
             $this->updater = new ComposerCompatibleUpdater(
                 GuzzleFileFetcher::createFromUri($url),
-                [],
                 // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
                 $this->initializeStorage($url, $config)
             );


### PR DESCRIPTION
We need to update our code after https://github.com/php-tuf/php-tuf/pull/291.