### PR TITLE
Allow TUF metadata to be loaded from a different place than the Composer package metadata

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -70,7 +70,9 @@ class TufValidatedComposerRepository extends ComposerRepository
             // prefixed with that.
             $repoConfig['url'] = "$url/targets";
 
-            $io->debug("[TUF] Packages from $url are verified by TUF. Metadata will be downloaded from $metadataUrl and targets will be downloaded from " . $repoConfig['url']);
+            $io->debug("[TUF] Packages from $url are verified by TUF.");
+            $io->debug("[TUF] Metadata source: $metadataUrl");
+            $io->debug("[TUF] Targets source: " . $repoConfig['url']);
         } else {
             // @todo Usability assessment. Should we output this for other repo types, or not at all?
             $io->warning("Authenticity of packages from $url are not verified by TUF.");

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -70,7 +70,7 @@ class TufValidatedComposerRepository extends ComposerRepository
             // prefixed with that.
             $repoConfig['url'] = "$url/targets";
 
-            $io->debug("[TUF] Packages from $url are verified with base URL " . $repoConfig['url']);
+            $io->debug("[TUF] Packages from $url are verified by TUF. Metadata will be downloaded from $metadataUrl and targets will be downloaded from " . $repoConfig['url']);
         } else {
             // @todo Usability assessment. Should we output this for other repo types, or not at all?
             $io->warning("Authenticity of packages from $url are not verified by TUF.");

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -52,9 +52,15 @@ class TufValidatedComposerRepository extends ComposerRepository
         $this->io = $io;
         $url = rtrim($repoConfig['url'], '/');
 
-        if (isset($repoConfig['tuf'])) {
+        if (!empty($repoConfig['tuf'])) {
+            // TUF metadata can optionally be loaded from a different place than the Composer package metadata.
+            $metadataUrl = $repoConfig['tuf']['metadata-url'] ?? "$url/metadata/";
+            if (!str_ends_with($metadataUrl, '/')) {
+                $metadataUrl .= '/';
+            }
+
             $this->updater = new ComposerCompatibleUpdater(
-                new SizeCheckingLoader(new Loader($httpDownloader, "$url/metadata/")),
+                new SizeCheckingLoader(new Loader($httpDownloader, $metadataUrl)),
                 // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
                 $this->initializeStorage($url, $config)
             );

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -145,7 +145,9 @@ class ComposerCommandsTest extends TestCase
             ->getErrorOutput();
         $this->assertStringContainsString('TUF integration enabled.', $debug);
         $this->assertStringContainsString('[TUF] Root metadata for http://localhost:8080 loaded from ', $debug);
-        $this->assertStringContainsString('[TUF] Packages from http://localhost:8080 are verified with base URL http://localhost:8080/targets', $debug);
+        $this->assertStringContainsString('[TUF] Packages from http://localhost:8080 are verified by TUF.', $debug);
+        $this->assertStringContainsString('[TUF] Metadata source: http://localhost:8080/metadata/', $debug);
+        $this->assertStringContainsString('[TUF] Targets source: http://localhost:8080/targets', $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' limited to 120 bytes.", $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' validated.", $debug);
         $this->assertStringContainsString("[TUF] Target 'files/packages/8/p2/drupal/token.json' limited to 1379 bytes.", $debug);


### PR DESCRIPTION
In order to test with the staged TUF metadata built for packages.drupal.org, we need to be able to load the TUF metadata from a different URL than the Composer package metadata itself, because in the staging setup, the packages metadata lives on packages.drupal.org but the TUF metadata lives on a different server, even though they agree with each other. (This could be useful in real-life production set-ups.)

So this PR adds support for an optional `metadata-url` configuration option for a given repository.