### PR TITLE
Allow the default maximum number of bytes to be overridden

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -71,11 +71,6 @@ class TufValidatedComposerRepository extends ComposerRepository
                 $this->initializeStorage($url, $config)
             );
 
-            // The Python tool (which generates the server-side TUF repository) will
-            // put all signed files into /targets, so ensure that all downloads are
-            // prefixed with that.
-            $repoConfig['url'] = "$url/targets";
-
             $io->debug("[TUF] Packages from $url are verified by TUF.");
             $io->debug("[TUF] Metadata source: $metadataUrl");
             $io->debug("[TUF] Targets source: " . $repoConfig['url']);

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -11,6 +11,7 @@ use Composer\Repository\ComposerRepository;
 use Composer\Util\Http\Response;
 use Composer\Util\HttpDownloader;
 use GuzzleHttp\Psr7\Utils;
+use Tuf\Client\Repository;
 use Tuf\Exception\NotFoundException;
 use Tuf\Loader\SizeCheckingLoader;
 use Tuf\Metadata\RootMetadata;
@@ -57,6 +58,11 @@ class TufValidatedComposerRepository extends ComposerRepository
             $metadataUrl = $repoConfig['tuf']['metadata-url'] ?? "$url/metadata/";
             if (!str_ends_with($metadataUrl, '/')) {
                 $metadataUrl .= '/';
+            }
+
+            $maxBytes = $repoConfig['tuf']['max-bytes'] ?? NULL;
+            if (is_int($maxBytes)) {
+                Repository::$maxBytes = $maxBytes;
             }
 
             $this->updater = new ComposerCompatibleUpdater(

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -71,6 +71,11 @@ class TufValidatedComposerRepository extends ComposerRepository
                 $this->initializeStorage($url, $config)
             );
 
+            // The Python tool (which generates the server-side TUF repository) will
+            // put all signed files into /targets, so ensure that all downloads are
+            // prefixed with that.
+            $repoConfig['url'] = "$url/targets";
+
             $io->debug("[TUF] Packages from $url are verified by TUF.");
             $io->debug("[TUF] Metadata source: $metadataUrl");
             $io->debug("[TUF] Targets source: " . $repoConfig['url']);

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -15,7 +15,9 @@ use Composer\Util\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Tuf\Client\Repository;
 use Tuf\Client\Updater;
+use Tuf\ComposerIntegration\ComposerCompatibleUpdater;
 use Tuf\ComposerIntegration\Plugin;
 use Tuf\ComposerIntegration\TufValidatedComposerRepository;
 
@@ -92,7 +94,7 @@ class ApiTest extends TestCase
     {
         $manager = $this->composer->getRepositoryManager();
 
-        $config['tuf'] = true;
+        $config += ['tuf' => true];
         $repository = $manager->createRepository('composer', $config);
         $this->setUpdater($repository, $updater);
         // Prepend the new repository to the list, so that it will be found first
@@ -302,5 +304,17 @@ class ApiTest extends TestCase
            'url' => 'https://packagist.example.net',
         ]);
         $this->assertInstanceOf(TufValidatedComposerRepository::class, $repository);
+    }
+
+    public function testMaxBytesOverride(): void
+    {
+        $updater = $this->prophesize(ComposerCompatibleUpdater::class);
+        $this->mockRepository($updater->reveal(), [
+            'url' => 'http://localhost:8080',
+            'tuf' => [
+                'max-bytes' => 123,
+            ],
+        ]);
+        $this->assertSame(123, Repository::$maxBytes);
     }
 }

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -147,7 +147,7 @@ class ComposerCommandsTest extends TestCase
         $this->assertStringContainsString('[TUF] Root metadata for http://localhost:8080 loaded from ', $debug);
         $this->assertStringContainsString('[TUF] Packages from http://localhost:8080 are verified by TUF.', $debug);
         $this->assertStringContainsString('[TUF] Metadata source: http://localhost:8080/metadata/', $debug);
-        $this->assertStringContainsString('[TUF] Targets source: http://localhost:8080/targets', $debug);
+        $this->assertStringContainsString('[TUF] Targets source: http://localhost:8080', $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' limited to 120 bytes.", $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' validated.", $debug);
         $this->assertStringContainsString("[TUF] Target 'files/packages/8/p2/drupal/token.json' limited to 1379 bytes.", $debug);

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -147,7 +147,7 @@ class ComposerCommandsTest extends TestCase
         $this->assertStringContainsString('[TUF] Root metadata for http://localhost:8080 loaded from ', $debug);
         $this->assertStringContainsString('[TUF] Packages from http://localhost:8080 are verified by TUF.', $debug);
         $this->assertStringContainsString('[TUF] Metadata source: http://localhost:8080/metadata/', $debug);
-        $this->assertStringContainsString('[TUF] Targets source: http://localhost:8080', $debug);
+        $this->assertStringContainsString('[TUF] Targets source: http://localhost:8080/targets', $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' limited to 120 bytes.", $debug);
         $this->assertStringContainsString("[TUF] Target 'packages.json' validated.", $debug);
         $this->assertStringContainsString("[TUF] Target 'files/packages/8/p2/drupal/token.json' limited to 1379 bytes.", $debug);


### PR DESCRIPTION
This is a follow-up to https://github.com/php-tuf/php-tuf/pull/353. We need to allow the maximum number of bytes to be changed by a configuration option for testing. This will also need a new alpha tag once it's merged.