### PR TITLE
Use Guzzle to download TUF metadata synchronously

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer-plugin-api": "^2.2",
         "php-tuf/php-tuf": "dev-main",
         "guzzlehttp/psr7": "^2.4",
-        "guzzlehttp/guzzle": "^7.8"
+        "guzzlehttp/guzzle": "^7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "composer-plugin-api": "^2.2",
         "php-tuf/php-tuf": "dev-main",
-        "guzzlehttp/psr7": "^2.4"
+        "guzzlehttp/psr7": "^2.4",
+        "guzzlehttp/guzzle": "^7.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\ComposerIntegration;
 
+use Composer\IO\IOInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\RequestOptions;
@@ -15,7 +16,7 @@ use Tuf\Loader\LoaderInterface;
  */
 class Loader implements LoaderInterface
 {
-    public function __construct(private ClientInterface $client)
+    public function __construct(private ClientInterface $client, private IOInterface $io)
     {
     }
 
@@ -38,7 +39,9 @@ class Loader implements LoaderInterface
         ];
 
         try {
-            return $this->client->get($locator, $options)->getBody();
+            $body = $this->client->get($locator, $options)->getBody();
+            $this->io->debug("[TUF] Downloaded $locator (" . $body->getSize() . " bytes)");
+            return $body;
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {
                 throw new RepoFileNotFound("$locator not found");

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -35,12 +35,11 @@ class Loader implements LoaderInterface
         };
         $options = [
             RequestOptions::PROGRESS => $progress,
-            RequestOptions::STREAM => true,
         ];
 
         try {
             $body = $this->client->get($locator, $options)->getBody();
-            $this->io->debug("[TUF] Downloaded $locator (" . $body->getSize() . " bytes)");
+            $this->io->debug("[TUF] Downloaded $locator");
             return $body;
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -70,7 +70,7 @@ class TufValidatedComposerRepository extends ComposerRepository
                 'base_uri' => $metadataUrl,
             ]);
             $this->updater = new ComposerCompatibleUpdater(
-                new SizeCheckingLoader(new Loader($client)),
+                new SizeCheckingLoader(new Loader($client, $io)),
                 // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
                 $this->initializeStorage($url, $config)
             );

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -10,6 +10,7 @@ use Composer\Plugin\PreFileDownloadEvent;
 use Composer\Repository\ComposerRepository;
 use Composer\Util\Http\Response;
 use Composer\Util\HttpDownloader;
+use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Utils;
 use Tuf\Client\Repository;
 use Tuf\Exception\NotFoundException;
@@ -65,8 +66,11 @@ class TufValidatedComposerRepository extends ComposerRepository
                 Repository::$maxBytes = $maxBytes;
             }
 
+            $client = new Client([
+                'base_uri' => $metadataUrl,
+            ]);
             $this->updater = new ComposerCompatibleUpdater(
-                new SizeCheckingLoader(new Loader($httpDownloader, $metadataUrl)),
+                new SizeCheckingLoader(new Loader($client)),
                 // @todo: Write a custom implementation of FileStorage that stores repo keys to user's global composer cache?
                 $this->initializeStorage($url, $config)
             );

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -2,15 +2,15 @@
 
 namespace Tuf\ComposerIntegration\Tests;
 
-use Composer\Downloader\MaxFileSizeExceededException;
-use Composer\Downloader\TransportException;
-use Composer\Util\HttpDownloader;
+use Composer\IO\NullIO;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Tuf\ComposerIntegration\Loader;
-use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\RepoFileNotFound;
 
 /**
@@ -22,21 +22,19 @@ class LoaderTest extends TestCase
 
     public function testLoader(): void
     {
-        $downloader = $this->prophesize(HttpDownloader::class);
-        $loader = new Loader($downloader->reveal(), '/metadata/');
+        $responses = new MockHandler();
 
-        $downloader->get('/metadata/root.json', ['max_file_size' => 129])
-            ->willReturn(new Response())
-            ->shouldBeCalled();
+        $handlerStack = HandlerStack::create($responses);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $loader = new Loader($client, new NullIO());
+
+        $responses->append(new Response());
         $this->assertInstanceOf(StreamInterface::class, $loader->load('root.json', 128));
 
-        // Any TransportException with a 404 error could should be converted
+        // Any ClientException with a 404 error could should be converted
         // into a RepoFileNotFound exception.
-        $exception = new TransportException();
-        $exception->setStatusCode(404);
-        $downloader->get('/metadata/bogus.txt', ['max_file_size' => 11])
-            ->willThrow($exception)
-            ->shouldBeCalled();
+        $responses->append(new Response(404));
         try {
             $loader->load('bogus.txt', 10);
             $this->fail('Expected a RepoFileNotFound exception, but none was thrown.');
@@ -44,31 +42,15 @@ class LoaderTest extends TestCase
             $this->assertSame('bogus.txt not found', $e->getMessage());
         }
 
-        // A MaxFileSizeExceededException should be converted into a
-        // DownloadSizeException.
-        $downloader->get('/metadata/too_big.txt', ['max_file_size' => 11])
-            ->willThrow(new MaxFileSizeExceededException())
-            ->shouldBeCalled();
-        try {
-            $loader->load('too_big.txt', 10);
-            $this->fail('Expected a DownloadSizeException, but none was thrown.');
-        } catch (DownloadSizeException $e) {
-            $this->assertSame('too_big.txt exceeded 10 bytes', $e->getMessage());
-        }
-
-        // Any other TransportException should be wrapped in a
+        // Any other ClientException should be wrapped in a
         // \RuntimeException.
-        $originalException = new TransportException('Whiskey Tango Foxtrot', -32);
-        $downloader->get('/metadata/wtf.txt', ['max_file_size' => 11])
-            ->willThrow($originalException)
-            ->shouldBeCalled();
+        $responses->append(new Response(420));
         try {
             $loader->load('wtf.txt', 10);
             $this->fail('Expected a RuntimeException, but none was thrown.');
         } catch (\RuntimeException $e) {
-            $this->assertSame($originalException->getMessage(), $e->getMessage());
-            $this->assertSame($originalException->getCode(), $e->getCode());
-            $this->assertSame($originalException, $e->getPrevious());
+            $this->assertSame(420, $e->getCode());
+            $this->assertInstanceOf('Throwable', $e->getPrevious());
         }
     }
 }


### PR DESCRIPTION
I think we might need to move away from Composer's `HttpDownloader`, and back to Guzzle, for getting TUF metadata.

`HttpDownloader` doesn't seem to be designed as a generic HTTP client, and I encountered very strange problems (`CURLOPT_WRITEHEADER resource has gone way`) when trying to do synchronous HTTP downloads with it (i.e., the TUF metadata) while asynchronous ones (i.e., actual Composer package metadata) are going on.

So I'm thinking it might make sense to just switch entirely back to Guzzle, and use it to download TUF metadata synchronously. We could just use the cURL API directly, but that's a bit low-level; Guzzle implements a lot of niceties there, and also provides a streams implementation (which we _do_ rely on in PHP-TUF).

