### PR TITLE
For better performance, Loader should send If-Modified-Since headers when downloading TUF metadata, and read unmodified data from persistent storage

### DIFF
--- a/src/ComposerFileStorage.php
+++ b/src/ComposerFileStorage.php
@@ -76,10 +76,21 @@ class ComposerFileStorage extends FileStorage
         if (file_exists($path)) {
             $modifiedTime = filemtime($path);
             if (is_int($modifiedTime)) {
-                return (new \DateTimeImmutable)->setTimestamp($modifiedTime);
+                // The @ prefix tells \DateTimeImmutable that $modifiedTime is
+                // a UNIX timestamp.
+                return new \DateTimeImmutable("@$modifiedTime");
             }
             throw new \RuntimeException("Could not get the modification time for '$path'.");
         }
         return null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read(string $name): ?string
+    {
+        return parent::read($name);
+    }
+
 }

--- a/src/ComposerFileStorage.php
+++ b/src/ComposerFileStorage.php
@@ -57,4 +57,29 @@ class ComposerFileStorage extends FileStorage
         ]);
         return new static($basePath);
     }
+
+    /**
+     * Returns the time a stored file was last modified.
+     *
+     * @param string $name
+     *   The name of the file to check, without its `.json` extension.
+     *
+     * @return \DateTimeImmutable|null
+     *   The time the file was last modified, or null if the file doesn't exist.
+     *
+     * @throws \RuntimeException
+     *   If the file exists but its modification time could not be determined.
+     */
+    public function getModifiedTime(string $name): ?\DateTimeImmutable
+    {
+        $path = $this->toPath($name);
+        if (file_exists($path)) {
+            $modifiedTime = filemtime($path);
+            if (is_int($modifiedTime)) {
+                return (new \DateTimeImmutable)->setTimestamp($modifiedTime);
+            }
+            throw new \RuntimeException("Could not get the modification time for '$path'.");
+        }
+        return null;
+    }
 }

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -96,8 +96,12 @@ class LoaderTest extends TestCase
             ],
         ];
         $url = '2.test.json';
-        $response = new Response(['url' => $url], 304, [], null);
-        $downloader->get($url, $options)->willReturn($response)->shouldBeCalled();
+        $response = $this->prophesize(Response::class);
+        $response->getStatusCode()->willReturn(304)->shouldBeCalled();
+        $response->getBody()->shouldNotBeCalled();
+        $downloader->get($url, $options)
+            ->willReturn($response->reveal())
+            ->shouldBeCalled();
 
         $loader = new Loader($downloader->reveal(), $storage);
         // Since the response has no actual body data, the fact that we get the contents

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
+use Tuf\ComposerIntegration\ComposerFileStorage;
 use Tuf\ComposerIntegration\Loader;
 use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\RepoFileNotFound;
@@ -23,7 +24,8 @@ class LoaderTest extends TestCase
     public function testLoader(): void
     {
         $downloader = $this->prophesize(HttpDownloader::class);
-        $loader = new Loader($downloader->reveal(), '/metadata/');
+        $storage = $this->prophesize(ComposerFileStorage::class);
+        $loader = new Loader($downloader->reveal(), $storage->reveal(), '/metadata/');
 
         $downloader->get('/metadata/root.json', ['max_file_size' => 129])
             ->willReturn(new Response())

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -82,8 +82,8 @@ class LoaderTest extends TestCase
         $storage = ComposerFileStorage::create('https://example.net/packages', $config);
 
         $method = new \ReflectionMethod($storage, 'write');
-        $method->invoke($storage, 'test', 'Some test data.');
         $method->setAccessible(true);
+        $method->invoke($storage, 'test', 'Some test data.');
         $modifiedTime = $storage->getModifiedTime('test')->format('D, d M Y H:i:s');
 
         $downloader = $this->prophesize(HttpDownloader::class);

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -83,6 +83,7 @@ class LoaderTest extends TestCase
 
         $method = new \ReflectionMethod($storage, 'write');
         $method->invoke($storage, 'test', 'Some test data.');
+        $method->setAccessible(true);
         $modifiedTime = $storage->getModifiedTime('test')->format('D, d M Y H:i:s');
 
         $downloader = $this->prophesize(HttpDownloader::class);


### PR DESCRIPTION
Right now, we have a big performance problem, which is that we _always_ download TUF metadata from the server, even if we already have the most up-to-date version of it in persistent storage. That's real bad.

We need to fix this by sending an `If-Modified-Since` header with these requests. If the server supports them, it should reply to requests for unchanged metadata with `304 Not Modified`, which should be our cue to load the data from persistent storage.