### PR TITLE
TUF target names need to be derived more intelligently

### DIFF
--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -193,7 +193,11 @@ class TufValidatedComposerRepository extends ComposerRepository
     private function getTargetFromUrl(string $url): string
     {
         $config = $this->getRepoConfig();
-        $target = str_replace($config['url'], '', $url);
+        if (str_starts_with($url, $config['url'])) {
+            $target = str_replace($config['url'], '', $url);
+        } else {
+            $target = parse_url($url, PHP_URL_PATH);
+        }
         return urldecode(ltrim($target, '/'));
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -322,7 +322,8 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::getTargetFromUrl
+     * @covers \Tuf\ComposerIntegration\TufValidatedComposerRepository::prepareMetadata
+     * @covers \Tuf\ComposerIntegration\TufValidatedComposerRepository::getTargetFromUrl
      */
     public function testTargetFromUrl(): void
     {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -322,6 +322,16 @@ class ApiTest extends TestCase
     }
 
     /**
+     * Tests that the URLs of Composer metadata files can be mapped to TUF targets.
+     * For example, given a repository URL of `https://example.com/packages`:
+     *
+     * - If the metadata URL starts with the repository URL, the repository URL should
+     *   be stripped out to derive the target name. For example, if the metadata URL is
+     *   `https://example.com/packages/file.json`, the target name should be `file.json`.
+     * - Otherwise, the metadata URL's path component should be used as the target name.
+     *   For example, if the metadata URL is `https://example.com/package/info.json`,
+     *   the target name should be `package/info.json`.
+     *
      * @covers \Tuf\ComposerIntegration\TufValidatedComposerRepository::prepareMetadata
      * @covers \Tuf\ComposerIntegration\TufValidatedComposerRepository::getTargetFromUrl
      */


### PR DESCRIPTION
This plugin has a bug which prevents it from working with the packages.drupal.org repository (or its staging server). The problem is that, when downloading Composer metadata, the TUF target names need to be derived from the metadata URLs. The URLs are, sadly, not consistent on packages.drupal.org -- `packages.json` exists at `https://packages.drupal.org/8/packages.json`, but the actual package-specific metadata lives at `https://packages.drupal.org/files/8/p2/drupal/PACKAGE_NAME.json`, which doesn't actually include the URL of the repo itself (`https://packages.drupal.org/8`). So the current method is insufficient, and it derives the wrong target name, which causes TUF to not be able to find it, which breaks things.

I think we need to take a two-pronged approach here. If the URL of the downloaded metadata starts with the URL of the Composer repository, we can safely use our old way (strip off the URL of the repository, and the resulting string is the target name). Otherwise, we have to assume that the path component of the URL (`/files/8/p2/drupal/PACKAGE_NAME.json`) is the name of the target.