### PR TITLE
ComposerCommandsTest should start and stop the PHP web server automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,10 +97,8 @@ jobs:
           name: fixture
       - name: Extract fixture
         run: tar -x -v -f fixture.tar.gz
-      - name: Start web server and run tests
-        run: |
-          php -S localhost:8080 -t ./tests/server &
-          vendor/bin/phpunit ./tests --debug
+      - name: Run tests
+        run: vendor/bin/phpunit ./tests --debug
       - name: Check dependencies for known security vulnerabilities (legacy)
         if: matrix.composer == 2.2
         run: composer require --update-with-all-dependencies roave/security-advisories:dev-latest

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "composer/composer": "^2.1",
         "phpunit/phpunit": "^9.5",
         "phpspec/prophecy-phpunit": "^2.0",
-        "symfony/process": "^6.3"
+        "symfony/process": "^6"
     },
     "scripts": {
         "make-fixture": [

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "require-dev": {
         "composer/composer": "^2.1",
         "phpunit/phpunit": "^9.5",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "symfony/process": "^6.3"
     },
     "scripts": {
         "make-fixture": [


### PR DESCRIPTION
Right now, you have to run a specific `php -S` command to run all tests. It's annoying insider knowledge and it's not documented.

We should probably just start and stop the server automatically in the test, using the `Process` component.