### PR TITLE
Only audit packages we actually provide

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           # @todo This is needed because Composer 2.6.5 declared support for
           # Symfony 7, but isn't actually compatible with it. We can remove
           # this line when Composer 2.6.6 or later is released.
-          composer require 'symfony/console:6.4.0' --no-update
+          composer require 'symfony/console:6.0.19' --no-update
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
           composer install ${{ env.COMPOSER_FLAGS }}
+          composer why symfony/console
       - name: Download fixture
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           # @todo This is required because Composer 2.6.5 declared support for
           # Symfony 7, but is not actually compatible with it. This line can be
           # removed when Composer 2.6.6 or later is released.
-          composer require "symfony/console:~6.4"
+          composer require 'symfony/console:^6'
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,10 +90,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
-          # @todo This is required because Composer 2.6.5 declared support for
-          # Symfony 7, but is not actually compatible with it. This line can be
-          # removed when Composer 2.6.6 or later is released.
-          composer require 'symfony/console:>=6 && <7' --no-update
+          # @todo This is needed because Composer 2.6.5 declared support for
+          # Symfony 7, but isn't actually compatible with it. We can remove
+          # this line when Composer 2.6.6 or later is released.
+          composer require 'symfony/console:6.4.0' --no-update
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           # @todo This is required because Composer 2.6.5 declared support for
           # Symfony 7, but is not actually compatible with it. This line can be
           # removed when Composer 2.6.6 or later is released.
-          composer require 'symfony/console:<7'
+          composer require 'symfony/console:>=6 && <7' --no-update
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           # @todo This is required because Composer 2.6.5 declared support for
           # Symfony 7, but is not actually compatible with it. This line can be
           # removed when Composer 2.6.6 or later is released.
-          composer require 'symfony/console:^6'
+          composer require 'symfony/console:<7'
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           # Symfony 7, but is not actually compatible with it due to poor test
           # coverage. This is since fixed, and this line can be removed when Composer
           # 2.6.6 or later is released.
-          composer require symfony/console:^6 composer/composer:^2.6.5 --no-update
+          composer require "symfony/console:^6"
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           # Symfony 7, but is not actually compatible with it due to poor test
           # coverage. This is since fixed, and this line can be removed when Composer
           # 2.6.6 or later is released.
-          composer require symfony/console:^6 --no-update
+          composer require symfony/console:^6 composer/composer:^2.6.5 --no-update
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,12 @@ jobs:
       - name: Install dependencies
         run: |
           composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+          # @todo This is required because Composer 2.6.5 shipped with support for
+          # Symfony 7, but is not actually compatible with it due to poor test
+          # coverage. This is since fixed, and this line can be removed when Composer
+          # 2.6.6 or later is released.
+          composer require symfony/console:^6 --no-update
           composer install ${{ env.COMPOSER_FLAGS }}
-          composer why symfony/console
       - name: Download fixture
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
-          # @todo This is required because Composer 2.6.5 shipped with support for
-          # Symfony 7, but is not actually compatible with it due to poor test
-          # coverage. This is since fixed, and this line can be removed when Composer
-          # 2.6.6 or later is released.
-          composer require "symfony/console:^6"
+          # @todo This is required because Composer 2.6.5 declared support for
+          # Symfony 7, but is not actually compatible with it. This line can be
+          # removed when Composer 2.6.6 or later is released.
+          composer require "symfony/console:~6.4"
           composer install ${{ env.COMPOSER_FLAGS }}
       - name: Download fixture
         uses: actions/download-artifact@v3

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -272,33 +272,33 @@ class TufValidatedComposerRepository extends ComposerRepository
         }
     }
 
-  /**
-   * {@inheritDoc}
-   */
-    public function getSecurityAdvisories(array $packageConstraintMap, bool $allowPartialAdvisories = FALSE): array
+    /**
+     * {@inheritDoc}
+     */
+    public function getSecurityAdvisories(array $packageConstraintMap, bool $allowPartialAdvisories = false): array
     {
-      $patterns = $this->getRepoConfig()['tuf']['security-advisory-patterns'] ?? null;
+        $patterns = $this->getRepoConfig()['tuf']['security-advisory-patterns'] ?? null;
 
-      if ($patterns === null) {
-        return parent::getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);
-      }
-
-      foreach (array_keys($packageConstraintMap) as $packageName) {
-        $isOurs = false;
-        foreach ($patterns as $pattern) {
-          if (fnmatch($pattern, $packageName)) {
-            $isOurs = true;
-          }
+        if ($patterns === null) {
+            return parent::getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);
         }
-        if (!$isOurs) {
-          $this->io->debug("[TUF] Refusing to audit $packageName because it is not provided by this repository.");
-          unset($packageConstraintMap[$packageName]);
-        }
-      }
 
-      if ($packageConstraintMap) {
-        return parent::getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);
-      }
-      return [];
+        foreach (array_keys($packageConstraintMap) as $packageName) {
+            $isOurs = false;
+            foreach ($patterns as $pattern) {
+                if (fnmatch($pattern, $packageName)) {
+                    $isOurs = true;
+                }
+            }
+            if (!$isOurs) {
+                $this->io->debug("[TUF] Refusing to audit $packageName because it is not provided by this repository.");
+                unset($packageConstraintMap[$packageName]);
+            }
+        }
+
+        if ($packageConstraintMap) {
+            return parent::getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);
+        }
+        return [];
     }
 }

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -277,7 +277,7 @@ class TufValidatedComposerRepository extends ComposerRepository
    */
     public function getSecurityAdvisories(array $packageConstraintMap, bool $allowPartialAdvisories = FALSE): array
     {
-      $patterns = $this->loadRootServerFile(600)['available-package-patterns'] ?? null;
+      $patterns = $this->getRepoConfig()['tuf']['security-advisory-patterns'] ?? null;
 
       if ($patterns === null) {
         return parent::getSecurityAdvisories($packageConstraintMap, $allowPartialAdvisories);

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -290,8 +290,10 @@ class TufValidatedComposerRepository extends ComposerRepository
                     $isOurs = true;
                 }
             }
-            if (!$isOurs) {
-                $this->io->debug("[TUF] Refusing to audit $packageName because it is not provided by this repository.");
+            if ($isOurs) {
+                $this->io->debug("[TUF] Auditing $packageName");
+            } else {
+                $this->io->debug("[TUF] Not auditing $packageName because it is not provided by this repository.");
                 unset($packageConstraintMap[$packageName]);
             }
         }


### PR DESCRIPTION
I discovered why Composer makes so many extra requests for packages that are not part of a particular repository (as surfaced in https://github.com/composer/composer/issues/11704 and https://github.com/php-tuf/drupal-project/pull/1) -- `composer require` and `composer update` will do a security audit by default, unless you pass the `--no-audit` option. While auditing, repositories that support it are queried for all packages, even ones they don't provide.

To be clear, this is an upstream bug in Composer and still needs to be fixed; I will update and repurpose https://github.com/composer/composer/issues/11704. But we can work around it by overriding `ComposerRepository::getSecurityAdvisories()` so that, if we are using an `available-package-patterns` filter, we don't try to get security advisories for packages we don't provide.