### PR TITLE
require php-tuf/php-tuf that is compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           retention-days: 5
 
   test:
-    name: Test with Composer ${{ matrix.composer }} and PHP ${{ matrix.php }}
+    name: Test with PHP ${{ matrix.php }}
     needs: fixture
     runs-on: ubuntu-latest
     strategy:
@@ -75,7 +75,6 @@ jobs:
       max-parallel: 10
       matrix:
         php: ['8.0', '8.1', '8.2']
-        composer: [2, 2.2]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -84,7 +83,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v${{ matrix.composer }}
+          tools: composer:v2
           extensions: sodium, json
       - name: Install dependencies
         run: |
@@ -98,9 +97,5 @@ jobs:
         run: tar -x -v -f fixture.tar.gz
       - name: Run tests
         run: vendor/bin/phpunit ./tests --debug
-      - name: Check dependencies for known security vulnerabilities (legacy)
-        if: matrix.composer == 2.2
-        run: composer require --update-with-all-dependencies roave/security-advisories:dev-latest
       - name: Check dependencies for known security vulnerabilities
-        if: matrix.composer == 2
         run: 'composer audit'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,13 @@ jobs:
           retention-days: 5
 
   test:
-    name: Test on ${{ matrix.operating-system }} with Composer ${{ matrix.composer }} and PHP ${{ matrix.php }}
+    name: Test with Composer ${{ matrix.composer }} and PHP ${{ matrix.php }}
     needs: fixture
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 10
       matrix:
-        operating-system: [ubuntu-latest, macos-latest, windows-latest]
         php: ['8.0', '8.1', '8.2']
         composer: [2, 2.2]
     steps:

--- a/.github/workflows/drupal-recommended-project.yml
+++ b/.github/workflows/drupal-recommended-project.yml
@@ -1,0 +1,37 @@
+name: Drupal recommended-project Compatibility
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 3 */2 * *'
+
+jobs:
+  composer-project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout self
+        uses: actions/checkout@v2
+        with:
+          path: composer-integration
+
+      - name: Install PHP and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+
+      - name: Create Drupal Project
+        run: |
+          composer create-project drupal/recommended-project project_name
+          cd project_name
+          # Set dev stability to allow for php-tuf/php-tuf to be installed.
+          composer config minimum-stability dev
+          composer config --no-plugins allow-plugins.php-tuf/composer-integration true
+          composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+          composer config repositories.vcs-php-tuf vcs https://github.com/php-tuf/php-tuf.git
+          composer config repositories.local path ../composer-integration
+          composer require php-tuf/composer-integration:@dev --with-all-dependencies

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://github.com/php-tuf/composer-integration/actions/workflows/build.yml/badge.svg)
 
-Experimental Composer plugin marrying Composer 2.2 and later to [PHP-TUF](https://github.com/php-tuf/php-tuf).
+Experimental Composer plugin marrying Composer 2.6 and later to [PHP-TUF](https://github.com/php-tuf/php-tuf).
 
 This plugin seeks to demonstrate adding TUF security to
   * Composer's package discovery process when using Composer v2 package repositories.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ## IMPORTANT
 
-This plugin, as well as the [PHP-TUF library](https://github.com/php-tuf/php-tuf) it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework. Additionally, this plugin requires Composer 2.2 or later, which has not yet been released.
+This plugin, as well as the [PHP-TUF library](https://github.com/php-tuf/php-tuf) it depends on, is in a pre-release state and is not considered a complete or secure implementation of the TUF framework.
 
 This plugin should currently only be used for testing, development and feedback. *Do NOT use in production for secure downloads!!*
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "composer-plugin-api": "^2.2",
+        "composer-plugin-api": "^2.6",
         "php-tuf/php-tuf": "dev-main#cc5ce0c40caf2e909c6fe13b38784fb91fac612a",
         "guzzlehttp/psr7": "^2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "composer-plugin-api": "^2.2",
-        "php-tuf/php-tuf": "dev-main",
+        "php-tuf/php-tuf": "dev-main#cc5ce0c40caf2e909c6fe13b38784fb91fac612a",
         "guzzlehttp/psr7": "^2.4"
     },
     "autoload": {


### PR DESCRIPTION
We are currently not compatible with php-tuf/php-tuf. Require the version we are compatible with until we can fix this. 

Also are builds are failing and this might because we have a matrix that runs our tests 18 times. We should cut that down until we figure why this is happening. If we are just going to ignore the build failures it doesn't matter that we have this matrix.