### PR TITLE
Remove Prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     "require-dev": {
         "composer/composer": "^2.1",
         "phpunit/phpunit": "^9.5",
-        "phpspec/prophecy-phpunit": "^2.0",
         "symfony/process": "^6"
     },
     "scripts": {


### PR DESCRIPTION
As part of bringing this project back online, we need to be compatible with PHP 8.2 and 8.3 (and later). Prophecy is not compatible with those versions and it doesn't look like it's going to be. We already removed it from PHP-TUF (https://github.com/php-tuf/php-tuf/pull/374), let's do the same here.