### PR TITLE
Remove outdated Usage section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,3 @@ All root key files must be stored in a directory called `tuf`, adjacent to the p
 
 The TUF repository must track the Composer repository, signing new versions of packages as they are released as well as
 the Composer package metadata for them.
-
-## Usage
-
-A sample TUF-protected Composer repository is included for development purposes. To set it up, first be sure you have
-`pipenv` installed, as per [these instructions](https://github.com/php-tuf/php-tuf#server-environment-setup-for-the-python-tuf-cli).
-Then, run `composer make-fixture`.
-
-An example Composer project that uses the sample TUF repo above is in `test-project`. To invoke Composer such that this
-plugin is used by the example project:
-```
-# Start a web server on localhost:8080.
-php -S localhost:8080
-cd test-project
-# Install the plugin.
-composer require php-tuf/composer-integration
-# Install a package with TUF protection! For development purposes, we need
-# to invoke a specific binary of Composer in order to avoid the autoloader
-# getting confused.
-../vendor/composer/composer/bin/composer require drupal/token
-```


### PR DESCRIPTION
README has a Usage section that's totally out of date and no longer makes sense. For now, we should just remove it. We will need some kind of usage section, indeed, but we'll probably want to do that some other way. I have ideas.