### PR TITLE
Tell Composer that this plugin modifies downloads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         }
     },
     "extra": {
-        "class": "Tuf\\ComposerIntegration\\Plugin"
+        "class": "Tuf\\ComposerIntegration\\Plugin",
+        "plugin-modifies-downloads": true
     },
     "require-dev": {
         "composer/composer": "^2.1",


### PR DESCRIPTION
See https://getcomposer.org/doc/articles/plugins.md#plugin-modifies-downloads.

I think we need this attribute for this plugin, even though we don't technically _modify_ the download URLs -- but we do _verify_ them, and therefore the behavior mentioned in the documentation (this plugin needs to be installed first) makes sense for us.