### PR TITLE
Prevent Composer from asking TUF for information about packages it doesn't intend to download

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,7 +96,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable
             // from the lock file.
             // @see \Tuf\ComposerIntegration\TufValidatedComposerRepository::configurePackageTransportOptions()
             $options = $context->getTransportOptions();
-            if (isset($options['tuf'])) {
+            if (empty($options['tuf'])) {
                 return null;
             }
             foreach ($this->repositoryManager->getRepositories() as $repository) {

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -164,9 +164,6 @@ class TufValidatedComposerRepository extends ComposerRepository
         $options['tuf'] = [
             'repository' => $url,
             'target' => $package->getName() . '/' . $package->getVersion(),
-            // Just for paranoia's sake, ensure this file won't get downloaded if TUF doesn't provide a proper length.
-            // @see ::preparePackage()
-            'max_file_size' => 0,
         ];
         $package->setTransportOptions($options);
     }

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -261,8 +261,10 @@ class TufValidatedComposerRepository extends ComposerRepository
     {
         if ($this->isTufEnabled($package)) {
             $options = $package->getTransportOptions();
+            $target = $options['tuf']['target'];
             // @see ::configurePackageTransportOptions()
-            $options['max_file_size'] = $this->updater->getLength($options['tuf']['target']);
+            $options['max_file_size'] = $this->updater->getLength($target);
+            $this->io->debug("[TUF] Target '$target' limited to " . $options['max_file_size'] . ' bytes.');
             $package->setTransportOptions($options);
         }
     }

--- a/src/TufValidatedComposerRepository.php
+++ b/src/TufValidatedComposerRepository.php
@@ -164,6 +164,9 @@ class TufValidatedComposerRepository extends ComposerRepository
         $options['tuf'] = [
             'repository' => $url,
             'target' => $package->getName() . '/' . $package->getVersion(),
+            // Just for paranoia's sake, ensure this file won't get downloaded if TUF doesn't provide a proper length.
+            // @see ::preparePackage()
+            'max_file_size' => 0,
         ];
         $package->setTransportOptions($options);
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -118,10 +118,8 @@ class ApiTest extends FunctionalTestBase
      */
     private function setUpdater(TufValidatedComposerRepository $repository, Updater $updater): void
     {
-        $reflector = new \ReflectionClass(TufValidatedComposerRepository::class);
-        $property = $reflector->getProperty('updater');
-        $property->setAccessible(true);
-        $property->setValue($repository, $updater);
+        $reflector = new \ReflectionProperty(TufValidatedComposerRepository::class, 'updater');
+        $reflector->setValue($repository, $updater);
     }
 
     /**
@@ -150,20 +148,12 @@ class ApiTest extends FunctionalTestBase
             }
         };
 
-        $updater = $this->createMock(ComposerCompatibleUpdater::class);
-        $updater->expects($this->atLeastOnce())
-            ->method('getLength')
-            ->with('drupal/token/1.9.0.0')
-            ->willReturn(36);
-        $this->setUpdater($repository, $updater);
-
         $package = new CompletePackage('drupal/token', '1.9.0.0', '1.9.0');
         $repository->configurePackageTransportOptions($package);
         $options = $package->getTransportOptions();
         $this->assertArrayHasKey('tuf', $options);
         $this->assertSame('https://packages.drupal.org/8', $options['tuf']['repository']);
         $this->assertSame('drupal/token/1.9.0.0', $options['tuf']['target']);
-        $this->assertSame(36, $options['max_file_size']);
     }
 
     /**

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -99,14 +99,12 @@ class ComposerCommandsTest extends FunctionalTestBase
         $this->assertIsArray($transportOptions);
         $this->assertSame('http://localhost:8080', $transportOptions['tuf']['repository']);
         $this->assertSame('drupal/token/1.9.0.0', $transportOptions['tuf']['target']);
-        $this->assertNotEmpty($transportOptions['max_file_size']);
 
         $transportOptions = $lock->findPackage('drupal/pathauto', '*')
             ?->getTransportOptions();
         $this->assertIsArray($transportOptions);
         $this->assertSame('http://localhost:8080', $transportOptions['tuf']['repository']);
         $this->assertSame('drupal/pathauto/1.12.0.0', $transportOptions['tuf']['target']);
-        $this->assertNotEmpty($transportOptions['max_file_size']);
 
         $this->composer(['remove', 'drupal/core-recommended']);
         $this->assertDirectoryDoesNotExist("$vendorDir/drupal/token");

--- a/tests/ComposerCommandsTest.php
+++ b/tests/ComposerCommandsTest.php
@@ -67,10 +67,13 @@ class ComposerCommandsTest extends FunctionalTestBase
         // size, and there should not be a message saying that it was validated.
         $this->assertStringContainsString("[TUF] Target 'drupal/token~dev.json' limited to " . TufValidatedComposerRepository::MAX_404_BYTES, $debug);
         $this->assertStringNotContainsStringIgnoringCase("[TUF] Target 'drupal/token~dev.json' validated.", $debug);
-        // The plugin won't report the maximum download size of package targets; instead, that
-        // information will be stored in the transport options saved to the lock file.
+        // The plugin should report the maximum download size of package targets.
+        $this->assertStringContainsString("[TUF] Target 'drupal/token/1.9.0.0' limited to 114056 bytes.", $debug);
+        $this->assertStringContainsString("[TUF] Target 'drupal/pathauto/1.12.0.0' limited to 123805 bytes.", $debug);
         $this->assertStringContainsString("[TUF] Target 'drupal/token/1.9.0.0' validated.", $debug);
-        // Metapackages should not be validated, because they don't actually install any files.
+        $this->assertStringContainsString("[TUF] Target 'drupal/pathauto/1.12.0.0' validated.", $debug);
+        // Metapackages should not be size-limited or validated, because they don't actually install any files.
+        $this->assertStringNotContainsString("[TUF] Target 'drupal/core/recommended/10.3.0.0' limited to ", $debug);
         $this->assertStringNotContainsStringIgnoringCase("[TUF] Target 'drupal/core-recommended/10.3.0.0' validated.", $debug);
 
         // Even though we are searching delegated roles for multiple targets, we should see the TUF metadata


### PR DESCRIPTION
I found the major flaw in the plugin which is causing colossal performance slowdowns.

The problem is that TUF is being asked to get the length of, basically, every release of a given package -- even if it's not going to install those releases. That's because we're calling Updater::getLength() in `configurePackageTransportOptions()`, which is called for every `Package` object -- that is, every _release_ -- of a given package in a repository.

The solution is to only get the length just before the package is actually _downloaded_ -- that is, where we handle the `PRE_PACKAGE_DOWNLOAD` event. We're already doing it for metadata; we just also need to do the same thing for packages.