### PR TITLE
Ensure protect command works when composer package type in repo list

### DIFF
--- a/src/ProtectCommand.php
+++ b/src/ProtectCommand.php
@@ -39,7 +39,7 @@ class ProtectCommand extends BaseCommand
 
         $key = $input->getArgument('repository');
         foreach ($repositories as $index => $repository) {
-            if ($index === $key || $repository['url'] === $key) {
+            if ($index === $key || (isset($repository['url']) && $repository['url'] === $key)) {
                 if ($repository['type'] !== 'composer') {
                     throw new \RuntimeException("Only Composer repositories can be protected by TUF.");
                 }


### PR DESCRIPTION
The repository type `package` does *not* have a require URL field - https://getcomposer.org/doc/05-repositories.md#package-2
So if any repo of type `package` exists fails hard.