### PR TITLE
fix: #138 PHP deprecation warning

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -88,7 +88,7 @@ class ApiTest extends FunctionalTestBase
      * @return TufValidatedComposerRepository
      *   The created repository object.
      */
-    private function mockRepository(Updater $updater = NULL, array $config = []): TufValidatedComposerRepository
+    private function mockRepository(?Updater $updater = NULL, array $config = []): TufValidatedComposerRepository
     {
         $manager = $this->composer->getRepositoryManager();
 


### PR DESCRIPTION
See #138

> Implicitly marking parameter $updater as nullable is deprecated, the
> explicit nullable type must be used instead...